### PR TITLE
Implement automatic related notes view updates based on cursor/reading position

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -139,7 +139,9 @@ export default class SonarPlugin extends Plugin {
         embeddingSearch,
         this.configManager,
         () => this.tokenizer!,
-        this.configManager.getLogger()
+        this.configManager.getLogger(),
+        ext => this.registerEditorExtension(ext),
+        processor => this.registerMarkdownPostProcessor(processor)
       );
     });
   }

--- a/src/ObsidianUtils.ts
+++ b/src/ObsidianUtils.ts
@@ -1,0 +1,77 @@
+import { MarkdownView } from 'obsidian';
+
+export interface DocumentContext {
+  lineStart: number;
+  lineEnd: number;
+  mode: 'source' | 'preview';
+  hasSelection: boolean;
+}
+
+export function getEditModeContext(view: MarkdownView): DocumentContext | null {
+  if (!view.editor) return null;
+
+  const selection = view.editor.getSelection();
+  if (selection) {
+    const from = view.editor.getCursor('from');
+    const to = view.editor.getCursor('to');
+    return {
+      lineStart: from.line,
+      lineEnd: to.line,
+      mode: 'source',
+      hasSelection: true,
+    };
+  }
+
+  const cursor = view.editor.getCursor();
+  return {
+    lineStart: cursor.line,
+    lineEnd: cursor.line,
+    mode: 'source',
+    hasSelection: false,
+  };
+}
+
+export function getReadingModeContext(
+  view: MarkdownView
+): DocumentContext | null {
+  const previewEl = view.containerEl.querySelector(
+    '.markdown-preview-view'
+  ) as HTMLElement;
+  if (!previewEl) return null;
+
+  const visibleBlocks = Array.from(
+    previewEl.querySelectorAll('[data-line-start][data-line-end]')
+  ).filter(el => {
+    const rect = (el as HTMLElement).getBoundingClientRect();
+    const previewRect = previewEl.getBoundingClientRect();
+    return rect.top < previewRect.bottom && rect.bottom > previewRect.top;
+  });
+
+  if (visibleBlocks.length === 0) return null;
+
+  const lineRanges = visibleBlocks
+    .map(el => {
+      const htmlEl = el as HTMLElement;
+      return {
+        start: Number(htmlEl.dataset.lineStart),
+        end: Number(htmlEl.dataset.lineEnd),
+      };
+    })
+    .filter(range => !isNaN(range.start) && !isNaN(range.end));
+
+  if (lineRanges.length === 0) return null;
+
+  return {
+    lineStart: Math.min(...lineRanges.map(r => r.start)),
+    lineEnd: Math.max(...lineRanges.map(r => r.end)),
+    mode: 'preview',
+    hasSelection: false,
+  };
+}
+
+export function getCurrentContext(view: MarkdownView): DocumentContext | null {
+  const mode = view.getMode();
+  return mode === 'source'
+    ? getEditModeContext(view)
+    : getReadingModeContext(view);
+}

--- a/src/QueryProcessor.ts
+++ b/src/QueryProcessor.ts
@@ -4,203 +4,182 @@ import type { Logger } from './Logger';
 
 export interface QueryOptions {
   fileName: string;
-  cursorLine: number;
-  followCursor: boolean;
-  withExtraction: boolean;
+  lineStart: number;
+  lineEnd: number;
+  hasSelection: boolean;
   maxTokens: number;
-  embeddingModel: string;
-  tokenizerModel: string | undefined;
-  ollamaUrl: string;
-  summaryModel: string;
   tokenizer: Tokenizer;
-  logger: Logger;
 }
 
-/**
- * Unified query processor with static functions
- */
-export class QueryProcessor {
-  static async process(
-    content: string,
-    options: QueryOptions
-  ): Promise<string> {
-    const fileNameTokens = await options.tokenizer.estimateTokens(
-      options.fileName
-    );
-    const remainingTokens = Math.max(10, options.maxTokens - fileNameTokens);
+export async function processQuery(
+  content: string,
+  options: QueryOptions
+): Promise<string> {
+  const fileNameTokens = await options.tokenizer.estimateTokens(
+    options.fileName
+  );
+  const remainingTokens = Math.max(10, options.maxTokens - fileNameTokens);
 
-    // Extract content based on followCursor setting
-    let extractedContent: string;
-    if (options.followCursor) {
-      extractedContent = await QueryProcessor.extractTokenBasedContent(
+  const extractedContent = options.hasSelection
+    ? await extractTokenBasedContent(
         content,
-        options.cursorLine,
+        options.lineStart,
+        options.lineEnd,
         remainingTokens,
-        false,
+        options.tokenizer
+      )
+    : await extractAroundCenter(
+        content,
+        options.lineStart,
+        remainingTokens,
         options.tokenizer
       );
+
+  return `${options.fileName}\n\n${extractedContent}`;
+}
+
+async function extractTokenBasedContent(
+  content: string,
+  lineStart: number,
+  lineEnd: number,
+  remainingTokens: number,
+  tokenizer: Tokenizer
+): Promise<string> {
+  const lines = content.split('\n');
+  let result: string[] = [];
+  let currentTokens = 0;
+
+  const startIdx = Math.max(0, lineStart);
+  const endIdx = Math.min(lines.length - 1, lineEnd);
+
+  for (let i = startIdx; i <= endIdx; i++) {
+    const lineTokens = await tokenizer.estimateTokens(lines[i]);
+    if (currentTokens + lineTokens <= remainingTokens) {
+      result.push(lines[i]);
+      currentTokens += lineTokens;
     } else {
-      extractedContent = await QueryProcessor.extractTokenBasedContent(
-        content,
-        0,
-        remainingTokens,
-        true,
-        options.tokenizer
-      );
-    }
-
-    // Combine filename and content
-    let query = `${options.fileName}\n\n${extractedContent}`;
-
-    // Apply LLM extraction if requested
-    if (options.withExtraction) {
-      query = await QueryProcessor.generateLLMExtraction(
-        query,
-        options.ollamaUrl,
-        options.summaryModel,
-        options.logger
-      );
-    }
-
-    return query;
-  }
-
-  private static async extractTokenBasedContent(
-    content: string,
-    startLine: number,
-    remainingTokens: number,
-    expandFromStart: boolean,
-    tokenizer: Tokenizer
-  ): Promise<string> {
-    const lines = content.split('\n');
-
-    if (expandFromStart) {
-      // Extract from the beginning of the file
-      let result: string[] = [];
-      let currentTokens = 0;
-
-      for (
-        let i = 0;
-        i < lines.length && currentTokens < remainingTokens;
-        i++
-      ) {
-        const lineTokens = await tokenizer.estimateTokens(lines[i]);
-        if (currentTokens + lineTokens <= remainingTokens) {
-          result.push(lines[i]);
-          currentTokens += lineTokens;
-        } else {
-          // Add partial line if it fits
-          const remainingSpace = remainingTokens - currentTokens;
-          if (remainingSpace > 10) {
-            const partialLine = await QueryProcessor.truncateToTokens(
-              lines[i],
-              remainingSpace,
-              tokenizer
-            );
-            result.push(partialLine);
-          }
-          break;
-        }
-      }
-      return result.join('\n');
-    } else {
-      // Extract around cursor position
-      let result: string[] = [];
-      let currentTokens = 0;
-
-      // Start from cursor line
-      if (startLine < lines.length) {
-        const cursorLineTokens = await tokenizer.estimateTokens(
-          lines[startLine]
+      const remainingSpace = remainingTokens - currentTokens;
+      if (remainingSpace > 10) {
+        const partialLine = await truncateToTokens(
+          lines[i],
+          remainingSpace,
+          tokenizer
         );
-        if (cursorLineTokens <= remainingTokens) {
-          result.push(lines[startLine]);
-          currentTokens += cursorLineTokens;
-        } else {
-          return await QueryProcessor.truncateToTokens(
-            lines[startLine],
-            remainingTokens,
-            tokenizer
-          );
-        }
+        result.push(partialLine);
       }
-
-      // Expand equally above and below
-      let above = startLine - 1;
-      let below = startLine + 1;
-
-      while (
-        currentTokens < remainingTokens &&
-        (above >= 0 || below < lines.length)
-      ) {
-        // Try to add line above
-        if (above >= 0) {
-          const lineTokens = await tokenizer.estimateTokens(lines[above]);
-          if (currentTokens + lineTokens <= remainingTokens) {
-            result.unshift(lines[above]);
-            currentTokens += lineTokens;
-            above--;
-          } else {
-            above = -1; // Stop expanding above
-          }
-        }
-
-        // Try to add line below
-        if (below < lines.length && currentTokens < remainingTokens) {
-          const lineTokens = await tokenizer.estimateTokens(lines[below]);
-          if (currentTokens + lineTokens <= remainingTokens) {
-            result.push(lines[below]);
-            currentTokens += lineTokens;
-            below++;
-          } else {
-            below = lines.length; // Stop expanding below
-          }
-        }
-      }
-
-      return result.join('\n');
+      break;
     }
   }
 
-  private static async truncateToTokens(
-    text: string,
-    maxTokens: number,
-    tokenizer: Tokenizer
-  ): Promise<string> {
-    const words = text.split(/\s+/);
-    let result: string[] = [];
-    let currentTokens = 0;
+  if (result.length === 0 && startIdx <= endIdx) {
+    return await truncateToTokens(lines[startIdx], remainingTokens, tokenizer);
+  }
 
-    for (const word of words) {
-      const wordTokens = await tokenizer.estimateTokens(word);
-      if (currentTokens + wordTokens <= maxTokens) {
-        result.push(word);
-        currentTokens += wordTokens;
+  return result.join('\n');
+}
+
+async function extractAroundCenter(
+  content: string,
+  centerLine: number,
+  remainingTokens: number,
+  tokenizer: Tokenizer
+): Promise<string> {
+  const lines = content.split('\n');
+  let result: string[] = [];
+  let currentTokens = 0;
+
+  if (centerLine >= lines.length) {
+    centerLine = lines.length - 1;
+  }
+
+  const centerLineTokens = await tokenizer.estimateTokens(lines[centerLine]);
+  if (centerLineTokens <= remainingTokens) {
+    result.push(lines[centerLine]);
+    currentTokens += centerLineTokens;
+  } else {
+    return await truncateToTokens(
+      lines[centerLine],
+      remainingTokens,
+      tokenizer
+    );
+  }
+
+  let above = centerLine - 1;
+  let below = centerLine + 1;
+
+  while (
+    currentTokens < remainingTokens &&
+    (above >= 0 || below < lines.length)
+  ) {
+    if (above >= 0) {
+      const lineTokens = await tokenizer.estimateTokens(lines[above]);
+      if (currentTokens + lineTokens <= remainingTokens) {
+        result.unshift(lines[above]);
+        currentTokens += lineTokens;
+        above--;
       } else {
-        break;
+        above = -1;
       }
     }
 
-    return result.join(' ');
+    if (below < lines.length && currentTokens < remainingTokens) {
+      const lineTokens = await tokenizer.estimateTokens(lines[below]);
+      if (currentTokens + lineTokens <= remainingTokens) {
+        result.push(lines[below]);
+        currentTokens += lineTokens;
+        below++;
+      } else {
+        below = lines.length;
+      }
+    }
   }
 
-  private static async generateLLMExtraction(
-    input: string,
-    ollamaUrl: string,
-    summaryModel: string,
-    logger: Logger
-  ): Promise<string> {
-    const ollamaClient = new OllamaClient({
-      ollamaUrl,
-      model: summaryModel,
-    });
+  return result.join('\n');
+}
 
-    const prompt = `Extract a search query from the following text for finding related documents in a RAG system.
+async function truncateToTokens(
+  text: string,
+  maxTokens: number,
+  tokenizer: Tokenizer
+): Promise<string> {
+  const words = text.split(/\s+/);
+  let result: string[] = [];
+  let currentTokens = 0;
+
+  for (const word of words) {
+    const wordTokens = await tokenizer.estimateTokens(word);
+    if (currentTokens + wordTokens <= maxTokens) {
+      result.push(word);
+      currentTokens += wordTokens;
+    } else {
+      break;
+    }
+  }
+
+  return result.join(' ');
+}
+
+export async function extractWithLLM(
+  input: string,
+  maxTokens: number,
+  ollamaUrl: string,
+  summaryModel: string,
+  logger: Logger
+): Promise<string> {
+  const ollamaClient = new OllamaClient({
+    ollamaUrl,
+    model: summaryModel,
+  });
+
+  const summaryTokens = Math.max(20, Math.floor(maxTokens * 0.4));
+  const keywordTokens = maxTokens - summaryTokens;
+
+  const prompt = `Extract a search query from the following text for finding related documents in a RAG system.
 Requirements:
 1. Write in the same language as the input text (do not translate)
-2. Start with ONE concise sentence summarizing the main topic or question (max 50 tokens)
-3. Follow with relevant keywords, concepts, and entities separated by commas
-4. Total output should be approximately 128 tokens
+2. Start with ONE concise sentence summarizing the main topic or question (max ${summaryTokens} tokens)
+3. Follow with relevant keywords, concepts, and entities separated by commas (max ${keywordTokens} tokens)
+4. Total output should be approximately ${maxTokens} tokens
 5. Focus on searchable terms that would help find similar or related documents
 
 Text to analyze follows:
@@ -208,12 +187,11 @@ Text to analyze follows:
 
 ${input}`;
 
-    try {
-      const extractionQuery = await ollamaClient.generate(prompt);
-      return extractionQuery.trim();
-    } catch (err) {
-      logger.error(`LLM extraction generation failed: ${err}`);
-      return input;
-    }
+  try {
+    const extractionQuery = await ollamaClient.generate(prompt);
+    return extractionQuery.trim();
+  } catch (err) {
+    logger.error(`LLM extraction generation failed: ${err}`);
+    return input;
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,6 @@ export interface CommonConfig {
 export interface ObsidianSettings extends CommonConfig {
   indexPath: string;
   debugMode: LogLevel;
-  followCursor: boolean;
   withExtraction: boolean;
   excludedPaths: string[]; // Array of paths/patterns to ignore
   autoOpenRelatedNotes: boolean;
@@ -45,7 +44,6 @@ export const DEFAULT_SETTINGS: ObsidianSettings = {
   ...DEFAULT_COMMON_CONFIG,
   indexPath: '', // Root of vault
   debugMode: 'error',
-  followCursor: false,
   withExtraction: false,
   excludedPaths: [], // Default to no ignored paths
   autoOpenRelatedNotes: true,

--- a/src/ui/RelatedNotesContent.svelte
+++ b/src/ui/RelatedNotesContent.svelte
@@ -4,7 +4,7 @@
   import { Tokenizer } from '../Tokenizer';
   import SearchResults from './SearchResults.svelte';
   import type { Logger } from '../Logger';
-  import { SquareDashedMousePointer, BrainCircuit, RefreshCw, createElement } from 'lucide';
+  import { BrainCircuit, RefreshCw, createElement } from 'lucide';
   import { onMount } from 'svelte';
 
   interface Props {
@@ -13,7 +13,6 @@
     store: any; // Svelte store
     logger: Logger;
     onRefresh: () => void;
-    onToggleFollowCursor: (value: boolean) => void;
     onToggleWithExtraction: (value: boolean) => void;
   }
 
@@ -23,7 +22,6 @@
     store,
     logger,
     onRefresh,
-    onToggleFollowCursor,
     onToggleWithExtraction,
   }: Props = $props();
 
@@ -33,22 +31,11 @@
   const results = $derived(storeState.results);
   const tokenCount = $derived(storeState.tokenCount);
   const status = $derived(storeState.status);
-  let followCursor = $state(configManager.get('followCursor'));
   let withExtraction = $state(configManager.get('withExtraction'));
-  let followCursorIcon: HTMLElement;
   let brainIcon: HTMLElement;
   let refreshIcon: HTMLElement;
 
   onMount(() => {
-    // Create and append lucide icons - DOM manipulation needed for Lucide icons
-    if (followCursorIcon) {
-      const icon = createElement(SquareDashedMousePointer);
-      icon.setAttribute('width', '16');
-      icon.setAttribute('height', '16');
-      // eslint-disable-next-line svelte/no-dom-manipulating
-      followCursorIcon.appendChild(icon);
-    }
-
     if (brainIcon) {
       const icon = createElement(BrainCircuit);
       icon.setAttribute('width', '16');
@@ -65,11 +52,6 @@
       refreshIcon.appendChild(icon);
     }
   });
-
-  function handleFollowCursorToggle() {
-    followCursor = !followCursor;
-    onToggleFollowCursor(followCursor);
-  }
 
   function handleWithExtractionToggle() {
     withExtraction = !withExtraction;
@@ -96,15 +78,6 @@
       </div>
 
       <div class="controls-container">
-        <button
-          class="icon-button follow-cursor-btn"
-          class:active={followCursor}
-          aria-label="Follow cursor - Updates search based on cursor position"
-          onclick={handleFollowCursorToggle}
-        >
-          <span bind:this={followCursorIcon}></span>
-        </button>
-
         <button
           class="icon-button with-llm-extraction-btn"
           class:active={withExtraction}


### PR DESCRIPTION
- Remove `followCursor` setting - now always active by tracking document position
- Add `ObsidianUtils` for extracting document context from Edit/Reading modes
  - Edit mode: Track cursor position and text selection via CodeMirror update listener
  - Reading mode: Extract visible line ranges from DOM with markdown post processor
- Refactor `QueryProcessor` to handle selection vs cursor-based extraction
  - Selection: Extract only selected range
  - No selection: Extract around cursor with context expansion
- Convert `QueryProcessor` and `ObsidianUtils` from classes to plain functions
- Factor out LLM extraction logic into separate `extractWithLLM` function
- Make LLM prompt token numbers dynamic based on `maxQueryTokens` config
- Improve state management in `RelatedNotesView`
  - Move `relatedNotesStore` from global to instance-level
  - Integrate `isProcessing` into store state
  - Cache processed query to prevent unnecessary updates
- Remove `followCursor` toggle from UI