### PR TITLE
bm25: Switch from subword tokenizer to IntlSegmenter

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -311,11 +311,7 @@ export default class SonarPlugin extends Plugin {
 
     let bm25Store: BM25Store;
     try {
-      bm25Store = await BM25Store.initialize(
-        db,
-        this.configManager,
-        this.embedder
-      );
+      bm25Store = await BM25Store.initialize(db, this.configManager);
     } catch (error) {
       this.error(`Failed to initialize BM25 store: ${error}`);
       new Notice(

--- a/src/IntlSegmenterTokenizer.ts
+++ b/src/IntlSegmenterTokenizer.ts
@@ -1,0 +1,42 @@
+// Intl.Segmenter is available in modern browsers and Node.js 16+
+interface SegmentData {
+  segment: string;
+  index: number;
+  input: string;
+  isWordLike?: boolean;
+}
+
+interface IntlSegmenter {
+  segment(input: string): Iterable<SegmentData>;
+}
+
+interface IntlSegmenterConstructor {
+  new (
+    locales?: string | string[],
+    options?: { granularity?: 'grapheme' | 'word' | 'sentence' }
+  ): IntlSegmenter;
+}
+
+/**
+ * Tokenizer using built-in Intl.Segmenter API
+ * Uses ICU library for word segmentation - zero additional dependencies
+ */
+export class IntlSegmenterTokenizer {
+  private segmenter: IntlSegmenter;
+
+  constructor(locale: string = 'ja') {
+    const SegmenterClass = (
+      Intl as unknown as { Segmenter: IntlSegmenterConstructor }
+    ).Segmenter;
+    this.segmenter = new SegmenterClass(locale, { granularity: 'word' });
+  }
+
+  tokenize(text: string): string[] {
+    const normalizedText = text.toLowerCase();
+    const segments = [...this.segmenter.segment(normalizedText)];
+
+    return segments
+      .filter(segment => segment.isWordLike)
+      .map(segment => segment.segment);
+  }
+}


### PR DESCRIPTION
Replace BPE subword tokenization with Intl.Segmenter for BM25 indexing. Subword tokenization breaks words into fragments (e.g., "frequency" -> "fre|que|ncy"), which hurts BM25 word matching. IntlSegmenter uses ICU word boundary detection, preserving whole words for better retrieval.

Changes:
- Add IntlSegmenterTokenizer using built-in Intl.Segmenter API
- Update BM25Store to use IntlSegmenterTokenizer instead of Embedder
- Remove Embedder dependency from BM25Store
- Add rebuildBM25Index method to IndexManager

Benchmark result (MIRACL Merged, nDCG@10):
- Before (BGE-M3 subword): 0.8827
- After (IntlSegmenter): 0.9023 (+2.2%)