### PR TITLE
refactor: Add ChunkId utilities for chunk ID format handling

### DIFF
--- a/src/BM25Store.ts
+++ b/src/BM25Store.ts
@@ -6,6 +6,8 @@ import {
 import { WithLogging } from './WithLogging';
 import { IntlSegmenterTokenizer } from './IntlSegmenterTokenizer';
 
+// TODO: Rename 'docId' to 'chunkId' in interfaces below (requires DB rebuild)
+
 /**
  * Posting list entry for inverted index
  */

--- a/src/MetadataStore.ts
+++ b/src/MetadataStore.ts
@@ -105,6 +105,7 @@ export class MetadataStore extends WithLogging {
           db.createObjectStore(STORE_BM25_INVERTED_INDEX, { keyPath: 'token' });
         }
         if (!db.objectStoreNames.contains(STORE_BM25_DOC_TOKENS)) {
+          // TODO: Rename keyPath from 'docId' to 'chunkId' (requires DB rebuild)
           db.createObjectStore(STORE_BM25_DOC_TOKENS, { keyPath: 'docId' });
         }
 

--- a/src/chunkId.ts
+++ b/src/chunkId.ts
@@ -1,0 +1,49 @@
+/**
+ * Chunk ID utilities
+ *
+ * Chunk IDs follow the format: "filePath#suffix"
+ * - Title chunks: "filePath#title"
+ * - Content chunks: "filePath#chunkIndex" (e.g., "path/to/file.md#0")
+ */
+
+const TITLE_SUFFIX = '#title';
+
+export const ChunkId = {
+  /**
+   * Create a chunk ID for a title
+   */
+  forTitle(filePath: string): string {
+    return `${filePath}${TITLE_SUFFIX}`;
+  },
+
+  /**
+   * Create a chunk ID for content at the given index
+   */
+  forContent(filePath: string, index: number): string {
+    return `${filePath}#${index}`;
+  },
+
+  /**
+   * Check if a chunk ID represents a title
+   */
+  isTitle(id: string): boolean {
+    return id.endsWith(TITLE_SUFFIX);
+  },
+
+  /**
+   * Extract the file path from a chunk ID
+   */
+  getFilePath(id: string): string {
+    const lastHashIndex = id.lastIndexOf('#');
+    return id.substring(0, lastHashIndex);
+  },
+
+  /**
+   * Extract the chunk index from a content chunk ID
+   * Returns NaN for title chunks
+   */
+  getChunkIndex(id: string): number {
+    const lastHashIndex = id.lastIndexOf('#');
+    return parseInt(id.substring(lastHashIndex + 1), 10);
+  },
+};


### PR DESCRIPTION
Centralize chunk ID format logic into a dedicated utility module. Chunk IDs follow the pattern "filePath#suffix" where suffix is either "title" or a numeric index. This replaces scattered string operations like `endsWith('#title')` and `lastIndexOf('#')` with semantic methods.