### PR TITLE
audio: Add experimental audio transcription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,55 @@ echo 'YOUR_TOKEN_HERE' > ~/.huggingface/token
 chmod 600 ~/.huggingface/token
 ```
 
+## Audio transcription (experimental)
+
+Sonar supports indexing audio files (`.m4a`, `.mp3`, `.wav`, `.webm`, `.ogg`,
+`.flac`) by transcribing them locally using
+[whisper.cpp](https://github.com/ggerganov/whisper.cpp). This feature is
+experimental and requires external dependencies.
+
+### Requirements
+
+1. **whisper.cpp**: Install via Homebrew or build from source:
+
+   ```bash
+   # macOS (Homebrew)
+   brew install whisper-cpp
+   ```
+
+2. **ffmpeg**: Required for audio format conversion:
+
+   ```bash
+   # macOS (Homebrew)
+   brew install ffmpeg
+   ```
+
+3. **Whisper model**: Download a GGML-format model from HuggingFace:
+
+   ```bash
+   # Create models directory
+   mkdir -p ~/whisper-models
+
+   # Download model (using Hugging Face CLI)
+   huggingface-cli download ggerganov/whisper.cpp \
+     ggml-large-v3-turbo-q5_0.bin \
+     --local-dir ~/whisper-models/
+   ```
+
+   For alternative models, see:
+   https://huggingface.co/ggerganov/whisper.cpp/tree/main
+
+### Configuration
+
+Configure audio transcription in Sonar settings:
+
+- **whisper-cli path**: Path to `whisper-cli` binary (default: `whisper-cli`)
+- **Whisper model path**: Path to the model file (e.g.,
+  `~/whisper-models/ggml-large-v3-turbo-q5_0.bin`)
+- **ffmpeg path**: Path to `ffmpeg` binary (default: `ffmpeg`)
+- **Transcription language**: Language code for transcription (default: `auto`
+  for auto-detection)
+
 ## Development
 
 See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -1,0 +1,226 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { spawn } from 'child_process';
+import { resolveServerPath } from './llamaCppUtils';
+import { formatDuration } from './utils';
+
+interface AudioLogger {
+  log(msg: string, ...data: unknown[]): void;
+  warn?(msg: string, ...data: unknown[]): void;
+  error?(msg: string, ...data: unknown[]): void;
+}
+
+const LOG_PREFIX = '[Sonar.Audio]';
+
+export interface AudioTranscriptionConfig {
+  whisperCliPath: string;
+  whisperModelPath: string;
+  ffmpegPath: string;
+  language: string;
+}
+
+function expandHomePath(filePath: string): string {
+  if (filePath.startsWith('~/')) {
+    return path.join(os.homedir(), filePath.slice(2));
+  }
+  return filePath;
+}
+
+const AUDIO_EXTENSIONS = ['m4a', 'mp3', 'wav', 'webm', 'ogg', 'flac'] as const;
+export type AudioExtension = (typeof AUDIO_EXTENSIONS)[number];
+
+export function isAudioExtension(ext: string): ext is AudioExtension {
+  return AUDIO_EXTENSIONS.includes(ext as AudioExtension);
+}
+
+export function getAudioExtensions(): readonly string[] {
+  return AUDIO_EXTENSIONS;
+}
+
+interface TranscribeOptions {
+  config: AudioTranscriptionConfig;
+  logger?: AudioLogger;
+}
+
+export interface TranscribeResult {
+  text: string;
+}
+
+async function getMetalResourcePath(): Promise<string | undefined> {
+  return new Promise(resolve => {
+    const brew = spawn('brew', ['--prefix', 'whisper-cpp']);
+    let output = '';
+
+    brew.stdout?.on('data', data => {
+      output += data.toString();
+    });
+
+    brew.on('close', code => {
+      if (code === 0 && output.trim()) {
+        resolve(path.join(output.trim(), 'share/whisper-cpp'));
+      } else {
+        resolve(undefined);
+      }
+    });
+
+    brew.on('error', () => {
+      resolve(undefined);
+    });
+  });
+}
+
+async function convertToWav(
+  inputPath: string,
+  outputPath: string,
+  ffmpegPath: string,
+  logger?: AudioLogger
+): Promise<void> {
+  const resolvedFfmpeg = await resolveServerPath(ffmpegPath);
+  const startTime = Date.now();
+
+  return new Promise((resolve, reject) => {
+    const args = [
+      '-i',
+      inputPath,
+      '-ar',
+      '16000', // 16kHz sample rate
+      '-ac',
+      '1', // mono
+      '-c:a',
+      'pcm_s16le', // 16-bit PCM
+      '-y', // overwrite output
+      outputPath,
+    ];
+
+    logger?.log(
+      `${LOG_PREFIX} Converting ${path.basename(inputPath)} to WAV...`
+    );
+
+    const ffmpeg = spawn(resolvedFfmpeg, args, { stdio: 'pipe' });
+
+    let stderr = '';
+    ffmpeg.stderr?.on('data', data => {
+      stderr += data.toString();
+    });
+
+    ffmpeg.on('error', error => {
+      if ('code' in error && error.code === 'ENOENT') {
+        reject(
+          new Error(
+            `ffmpeg not found. Please install ffmpeg: brew install ffmpeg`
+          )
+        );
+      } else {
+        reject(new Error(`Failed to start ffmpeg: ${error.message}`));
+      }
+    });
+
+    ffmpeg.on('close', code => {
+      if (code === 0) {
+        const duration = formatDuration(Date.now() - startTime);
+        logger?.log(`${LOG_PREFIX} Converted to WAV in ${duration}`);
+        resolve();
+      } else {
+        reject(new Error(`ffmpeg failed with code ${code}: ${stderr}`));
+      }
+    });
+  });
+}
+
+async function runWhisper(
+  wavPath: string,
+  options: TranscribeOptions
+): Promise<string> {
+  const { config, logger } = options;
+  const resolvedWhisper = await resolveServerPath(config.whisperCliPath);
+  const resolvedModelPath = expandHomePath(config.whisperModelPath);
+  const metalPath = await getMetalResourcePath();
+  const startTime = Date.now();
+
+  return new Promise((resolve, reject) => {
+    // Don't use -nt (no timestamps) to get segment-based output with timestamps
+    // We'll strip timestamps later but keep segment breaks as newlines
+    const args = [
+      '-l',
+      config.language,
+      '-m',
+      resolvedModelPath,
+      '-f',
+      wavPath,
+    ];
+
+    logger?.log(`${LOG_PREFIX} Transcribing...`);
+
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    if (metalPath) {
+      env.GGML_METAL_PATH_RESOURCES = metalPath;
+    }
+
+    const whisper = spawn(resolvedWhisper, args, { stdio: 'pipe', env });
+
+    let stdout = '';
+    let stderr = '';
+
+    whisper.stdout?.on('data', data => {
+      stdout += data.toString();
+    });
+
+    whisper.stderr?.on('data', data => {
+      stderr += data.toString();
+    });
+
+    whisper.on('error', error => {
+      if ('code' in error && error.code === 'ENOENT') {
+        reject(
+          new Error(
+            `whisper-cli not found. Please install whisper-cpp: brew install whisper-cpp`
+          )
+        );
+      } else {
+        reject(new Error(`Failed to start whisper-cli: ${error.message}`));
+      }
+    });
+
+    whisper.on('close', code => {
+      if (code === 0) {
+        // Strip timestamps from each line: [00:00:00.000 --> 00:00:02.000]  text
+        const text = stdout
+          .split('\n')
+          .map(line => line.replace(/^\[[\d:.,\s\->]+\]\s*/, '').trim())
+          .filter(line => line.length > 0)
+          .join('\n');
+        const duration = formatDuration(Date.now() - startTime);
+        logger?.log(
+          `${LOG_PREFIX} Transcribed ${text.length} characters in ${duration}`
+        );
+        resolve(text);
+      } else {
+        reject(new Error(`whisper-cli failed with code ${code}: ${stderr}`));
+      }
+    });
+  });
+}
+
+export async function transcribeAudio(
+  audioPath: string,
+  options: TranscribeOptions
+): Promise<TranscribeResult> {
+  const { config, logger } = options;
+
+  const tempDir = os.tmpdir();
+  const tempWavPath = path.join(
+    tempDir,
+    `sonar-audio-${Date.now()}-${Math.random().toString(36).slice(2)}.wav`
+  );
+
+  try {
+    await convertToWav(audioPath, tempWavPath, config.ffmpegPath, logger);
+    const text = await runWhisper(tempWavPath, options);
+    return { text };
+  } finally {
+    if (fs.existsSync(tempWavPath)) {
+      fs.unlinkSync(tempWavPath);
+    }
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,13 @@ export interface SonarSettings {
   aggRrfK: number; // RRF k parameter for rrf_per_doc (default: 60)
   retrievalMultiplier: number; // Multiplier for candidate retrieval (hybrid search fusion & reranking)
 
+  // Audio transcription configuration
+  // ==================================
+  audioWhisperCliPath: string; // Path to whisper-cli binary (e.g., 'whisper-cli')
+  audioWhisperModelPath: string; // Path to whisper.cpp model file (e.g., '~/whisper-models/ggml-large-v3-turbo-q5_0.bin')
+  audioFfmpegPath: string; // Path to ffmpeg binary (e.g., 'ffmpeg')
+  audioTranscriptionLanguage: string; // Language code for transcription (e.g., 'ja', 'en')
+
   // Logging configuration
   // =====================
   statusBarMaxLength: number; // Maximum characters in status bar (0 = no limit)
@@ -119,6 +126,13 @@ export const DEFAULT_SETTINGS: SonarSettings = {
   aggDecay: 0.95,
   aggRrfK: 60,
   retrievalMultiplier: 10,
+
+  // Audio transcription configuration
+  // ==================================
+  audioWhisperCliPath: 'whisper-cli',
+  audioWhisperModelPath: '',
+  audioFfmpegPath: 'ffmpeg',
+  audioTranscriptionLanguage: 'auto',
 
   // Logging configuration
   // =====================

--- a/src/fileFilters.ts
+++ b/src/fileFilters.ts
@@ -1,5 +1,6 @@
 import { TFile, Vault, normalizePath } from 'obsidian';
 import { ConfigManager } from './ConfigManager';
+import { getAudioExtensions } from './audio';
 
 /**
  * Utility functions for filtering files based on index path and excluded paths
@@ -42,7 +43,7 @@ function matchesExclusionPattern(filePath: string, pattern: string): boolean {
   );
 }
 
-const INDEXABLE_EXTENSIONS = ['md', 'pdf'];
+const INDEXABLE_EXTENSIONS = ['md', 'pdf', ...getAudioExtensions()];
 
 /**
  * Check if a file should be indexed based on configuration

--- a/src/ui/SettingTab.ts
+++ b/src/ui/SettingTab.ts
@@ -36,6 +36,7 @@ export class SettingTab extends PluginSettingTab {
     this.createChunkingConfigSection(containerEl);
     this.createEmbedderConfigSection(containerEl);
     this.createSearchParamsSection(containerEl);
+    this.createAudioConfigSection(containerEl);
     this.createLoggingConfigSection(containerEl);
     this.createBenchmarkConfigSection(containerEl);
   }
@@ -839,6 +840,80 @@ Larger values increase recall but may add noise; smaller values focus on high-qu
         .setValue(this.configManager.get('debugMode'))
         .onChange(async value => {
           await this.configManager.set('debugMode', value as LogLevel);
+        })
+    );
+  }
+
+  private createAudioConfigSection(containerEl: HTMLElement): void {
+    const audioDetails = containerEl.createEl('details', {
+      cls: 'sonar-settings-section',
+    });
+    audioDetails.createEl('summary', {
+      text: 'Audio transcription configuration',
+    });
+    const audioContainer = audioDetails.createDiv();
+
+    const whisperPathSetting = new Setting(audioContainer).setName(
+      'Whisper CLI path'
+    );
+    this.renderMarkdownDesc(
+      whisperPathSetting.descEl,
+      'Path to `whisper-cli` binary from whisper.cpp (e.g., `whisper-cli` or `/opt/homebrew/bin/whisper-cli`).'
+    );
+    whisperPathSetting.addText(text =>
+      text
+        .setPlaceholder('whisper-cli')
+        .setValue(this.configManager.get('audioWhisperCliPath'))
+        .onChange(async value => {
+          await this.configManager.set('audioWhisperCliPath', value);
+        })
+    );
+
+    const modelPathSetting = new Setting(audioContainer).setName(
+      'Whisper model path'
+    );
+    this.renderMarkdownDesc(
+      modelPathSetting.descEl,
+      'Path to whisper.cpp model file. Supports `~` for home directory (e.g., `~/whisper-models/ggml-large-v3-turbo-q5_0.bin`).'
+    );
+    modelPathSetting.addText(text =>
+      text
+        .setPlaceholder('~/whisper-models/ggml-large-v3-turbo-q5_0.bin')
+        .setValue(this.configManager.get('audioWhisperModelPath'))
+        .onChange(async value => {
+          await this.configManager.set('audioWhisperModelPath', value);
+        })
+    );
+
+    const ffmpegPathSetting = new Setting(audioContainer).setName(
+      'ffmpeg path'
+    );
+    this.renderMarkdownDesc(
+      ffmpegPathSetting.descEl,
+      'Path to `ffmpeg` binary (e.g., `ffmpeg` or `/opt/homebrew/bin/ffmpeg`).'
+    );
+    ffmpegPathSetting.addText(text =>
+      text
+        .setPlaceholder('ffmpeg')
+        .setValue(this.configManager.get('audioFfmpegPath'))
+        .onChange(async value => {
+          await this.configManager.set('audioFfmpegPath', value);
+        })
+    );
+
+    const languageSetting = new Setting(audioContainer).setName(
+      'Transcription language'
+    );
+    this.renderMarkdownDesc(
+      languageSetting.descEl,
+      'Language code for audio transcription (e.g., `auto` for auto-detection, `ja` for Japanese, `en` for English).'
+    );
+    languageSetting.addText(text =>
+      text
+        .setPlaceholder('auto')
+        .setValue(this.configManager.get('audioTranscriptionLanguage'))
+        .onChange(async value => {
+          await this.configManager.set('audioTranscriptionLanguage', value);
         })
     );
   }


### PR DESCRIPTION
Add local audio transcription using whisper-cpp for indexing audio files.
This is an experimental feature with hardcoded paths for MVP/demo purposes.

Features:
- Transcribe audio files (m4a, mp3, wav, webm, ogg, flac) using whisper-cli
- Convert audio to WAV format via ffmpeg before transcription
- Segment-based output with natural line breaks for better chunking
- File menu command to create transcription notes from indexed audio
- Metal GPU acceleration support on macOS

External dependencies (must be installed separately):
- whisper-cpp: brew install whisper-cpp
- ffmpeg: brew install ffmpeg
- Whisper model: ggml-large-v3-turbo-q5_0.bin in ~/whisper-models/