### PR TITLE
chat: Add LlamaCppChat component for LLM inference

### DIFF
--- a/src/LlamaCppChat.ts
+++ b/src/LlamaCppChat.ts
@@ -1,0 +1,175 @@
+import type { ChildProcess } from 'child_process';
+import type { ConfigManager } from './ConfigManager';
+import { WithLogging } from './WithLogging';
+import {
+  isModelCached,
+  downloadModel,
+  getModelCachePath,
+  findAvailablePort,
+  killServerProcess,
+  startLlamaServer,
+  waitForServerReady,
+  llamaServerChatCompletion,
+  type ChatMessage,
+  type ChatCompletionOptions,
+  type ChatCompletionResponse,
+} from './llamaCppUtils';
+
+export type { ChatMessage, ChatCompletionOptions, ChatCompletionResponse };
+
+/**
+ * Chat completion using llama.cpp server
+ * Manages a llama.cpp server process for chat/LLM inference
+ */
+export class LlamaCppChat extends WithLogging {
+  protected readonly componentName = 'LlamaCppChat';
+
+  private serverProcess: ChildProcess | null = null;
+  private port: number | null = null;
+  private exitHandlerBound: (() => void) | null = null;
+  private ready = false;
+
+  constructor(
+    private serverPath: string,
+    private modelRepo: string,
+    private modelFile: string,
+    protected configManager: ConfigManager,
+    private statusCallback: (status: string) => void,
+    private showNotice?: (msg: string, duration?: number) => void
+  ) {
+    super();
+  }
+
+  private updateStatus(status: string): void {
+    this.statusCallback(status);
+  }
+
+  async initialize(): Promise<void> {
+    this.log(`Initializing with model: ${this.modelRepo}/${this.modelFile}`);
+    this.updateStatus('Chat: Initializing...');
+
+    if (!isModelCached(this.modelRepo, this.modelFile)) {
+      this.log(`Model not found in cache, downloading...`);
+      await downloadModel(this.modelRepo, this.modelFile, progress => {
+        if (progress.status === 'progress') {
+          const percent = progress.percent.toFixed(0);
+          this.updateStatus(`Chat: Loading ${percent}%`);
+        }
+      });
+      this.log(`Model downloaded`);
+    } else {
+      this.log(`Using cached model`);
+    }
+
+    this.port = await findAvailablePort();
+    this.log(`Selected port: ${this.port}`);
+
+    await this.startServer();
+    await this.waitForReady();
+    this.log(`Initialized on port ${this.port}`);
+  }
+
+  private get serverUrl(): string {
+    if (!this.port) {
+      throw new Error('Server port not initialized');
+    }
+    return `http://localhost:${this.port}`;
+  }
+
+  private async startServer(): Promise<void> {
+    if (!this.port) {
+      throw new Error('Port not selected');
+    }
+
+    const modelPath = getModelCachePath(this.modelRepo, this.modelFile);
+
+    this.log(`Starting llama.cpp chat server (port: ${this.port})...`);
+
+    const args = [
+      '--model',
+      modelPath,
+      '--port',
+      this.port.toString(),
+      '--ctx-size',
+      '32768',
+      '--parallel',
+      '1',
+      '-kvu',
+      '-lv',
+      '0',
+    ];
+
+    const result = await startLlamaServer({
+      serverPath: this.serverPath,
+      args,
+      logger: this.configManager.getLogger(),
+      showNotice: this.showNotice,
+      onExit: () => {
+        this.ready = false;
+      },
+      serverType: 'llama.cpp chat server',
+    });
+
+    this.serverProcess = result.process;
+    this.exitHandlerBound = result.exitHandler;
+  }
+
+  private async waitForReady(): Promise<void> {
+    await waitForServerReady(this.serverUrl, this.configManager.getLogger());
+    this.ready = true;
+  }
+
+  /**
+   * Send a chat completion request
+   * @param messages Array of chat messages (conversation history)
+   * @param options Optional generation parameters
+   * @returns Promise that resolves to the completion response
+   */
+  async chat(
+    messages: ChatMessage[],
+    options: ChatCompletionOptions = {}
+  ): Promise<ChatCompletionResponse> {
+    if (!this.ready || !this.port) {
+      throw new Error('Chat server not initialized. Call initialize() first.');
+    }
+
+    const topK = this.configManager.get('chatTopK');
+    const defaultOptions: ChatCompletionOptions = {
+      temperature: this.configManager.get('chatTemperature'),
+      topK: topK > 0 ? topK : undefined,
+      topP: this.configManager.get('chatTopP'),
+      presencePenalty: this.configManager.get('chatPresencePenalty'),
+      cachePrompt: true,
+    };
+
+    const mergedOptions = { ...defaultOptions, ...options };
+
+    return llamaServerChatCompletion(this.serverUrl, messages, mergedOptions);
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  async cleanup(): Promise<void> {
+    this.log(`Cleaning up...`);
+
+    if (this.exitHandlerBound) {
+      process.off('exit', this.exitHandlerBound);
+      process.off('SIGINT', this.exitHandlerBound);
+      process.off('SIGTERM', this.exitHandlerBound);
+      this.exitHandlerBound = null;
+    }
+
+    if (this.serverProcess) {
+      this.log(`Stopping server on port ${this.port}`);
+      await killServerProcess(this.serverProcess, this.configManager.logger);
+      this.serverProcess = null;
+    }
+
+    this.port = null;
+    this.ready = false;
+
+    this.log(`Completed cleanup`);
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,13 +39,22 @@ export interface SonarSettings {
   chunkOverlap: number; // Overlapping tokens between chunks
   maxQueryTokens: number; // Maximum tokens for search queries
 
-  // Embedder configuration (llama.cpp)
-  // ===================================
+  // llama.cpp configuration
+  // =======================
   llamacppServerPath: string; // Path to llama.cpp server binary (e.g., 'llama-server')
   llamaEmbedderModelRepo: string; // HuggingFace repository for llama.cpp (e.g., 'BAAI/bge-m3-gguf')
   llamaEmbedderModelFile: string; // GGUF filename in the repository (e.g., 'bge-m3-q8_0.gguf')
   llamaRerankerModelRepo: string; // HuggingFace repository for reranker (e.g., 'gpustack/bge-reranker-v2-m3-GGUF')
   llamaRerankerModelFile: string; // GGUF filename for reranker (e.g., 'bge-reranker-v2-m3-Q8_0.gguf')
+  llamaChatModelRepo: string; // HuggingFace repository for chat model (e.g., 'Qwen/Qwen3-8B-GGUF')
+  llamaChatModelFile: string; // GGUF filename for chat model (e.g., 'qwen3-8b-q8_0.gguf')
+
+  // Chat generation parameters
+  // ==========================
+  chatTemperature: number; // Temperature for response generation (default: 0.6)
+  chatTopK: number; // Top-k sampling, 0 to disable (default: 0)
+  chatTopP: number; // Top-p (nucleus sampling) for response generation (default: 0.9)
+  chatPresencePenalty: number; // Presence penalty to reduce repetition (default: 0.5)
 
   // Search parameters
   // =================
@@ -102,13 +111,22 @@ export const DEFAULT_SETTINGS: SonarSettings = {
   chunkOverlap: 64,
   maxQueryTokens: 128,
 
-  // Embedder configuration (llama.cpp)
-  // ===================================
+  // llama.cpp configuration
+  // =======================
   llamacppServerPath: 'llama-server',
   llamaEmbedderModelRepo: 'ggml-org/bge-m3-Q8_0-GGUF',
   llamaEmbedderModelFile: 'bge-m3-q8_0.gguf',
   llamaRerankerModelRepo: 'gpustack/bge-reranker-v2-m3-GGUF',
   llamaRerankerModelFile: 'bge-reranker-v2-m3-Q8_0.gguf',
+  llamaChatModelRepo: 'Qwen/Qwen3-8B-GGUF',
+  llamaChatModelFile: 'qwen3-8b-q8_0.gguf',
+
+  // Chat generation parameters
+  // ==========================
+  chatTemperature: 0.6,
+  chatTopK: 0,
+  chatTopP: 0.9,
+  chatPresencePenalty: 0.5,
 
   // Search parameters
   // =================


### PR DESCRIPTION
Add `LlamaCppChat` class to manage llama.cpp server for chat/LLM inference, following the same pattern as `LlamaCppEmbedder` and `LlamaCppReranker`.

Features:
- Chat completion via `/v1/chat/completions` endpoint
- Configurable model via settings (`llamaChatModelRepo`, `llamaChatModelFile`)
- Default model: Qwen3-8B-Q8_0
- Status bar progress during model download
- Auto-reinitialize when model settings change
- KV cache reuse with `cache_prompt: true`
- Configurable generation parameters in settings:
  - Temperature (default: 0.6)
  - Top-p / nucleus sampling (default: 0.9)
  - Top-k sampling (default: 0 / disabled)
  - Presence penalty (default: 0.5)

The chat model is initialized in parallel with embedder and reranker during plugin startup.