### PR TITLE
chat: Implement chat window with context retrieval

### DIFF
--- a/src/Chat.ts
+++ b/src/Chat.ts
@@ -1,0 +1,294 @@
+import type {
+  LlamaCppChat,
+  ChatMessage,
+  ChatStreamDelta,
+} from './LlamaCppChat';
+import type {
+  ChatContextBuilder,
+  ChatContext,
+  ExplicitReference,
+} from './ChatContextBuilder';
+import type { ConfigManager } from './ConfigManager';
+import { WithLogging } from './WithLogging';
+
+const SYSTEM_PROMPT_BASE = `You are a helpful assistant.
+Always respond in the same language as the user's question.`;
+
+const SYSTEM_PROMPT_WITH_CONTEXT_INTRO = `You are an assistant that answers questions based on the user's notes.
+Use the following context to answer the question.
+Always respond in the same language as the user's question.
+When referencing information from the context, include the source using the exact wikilink format shown (e.g., [[Note name]] or [[Note name#Section]]).
+If you cannot find relevant information in the context, say so honestly.`;
+
+const EXPLICIT_REFS_EXPLANATION = `[Explicit References] contains notes explicitly specified by the user via [[wikilink]] syntax. These should be treated as primary sources for answering the question.`;
+
+const RETRIEVED_CONTEXT_EXPLANATION = `[Context] was retrieved using semantic search and reranked by relevance.
+Items are ordered from most to least relevant, but:
+- Not all items may be directly relevant to the question
+- The answer may not be contained in the context at all`;
+
+/**
+ * Chat turn with user message and assistant response
+ */
+export interface ChatTurn {
+  userMessage: string;
+  assistantMessage: string;
+  context?: ChatContext;
+  explicitRefs?: ExplicitReference[];
+}
+
+/**
+ * Chat session with optional context retrieval
+ * Manages context window and conversation history
+ */
+export class Chat extends WithLogging {
+  protected readonly componentName = 'Chat';
+
+  private history: ChatTurn[] = [];
+  private slotId: number;
+  private readonly maxContextTokens = 28000;
+
+  constructor(
+    private chatModel: LlamaCppChat,
+    private contextBuilder: ChatContextBuilder,
+    protected configManager: ConfigManager,
+    slotId: number = 0
+  ) {
+    super();
+    this.slotId = slotId;
+  }
+
+  /**
+   * Build messages array for the chat API with token budget management
+   */
+  private async buildMessages(
+    currentUserMessage: string,
+    currentContext?: ChatContext,
+    explicitRefs?: ExplicitReference[]
+  ): Promise<ChatMessage[]> {
+    const maxSystemPrompt =
+      SYSTEM_PROMPT_WITH_CONTEXT_INTRO +
+      EXPLICIT_REFS_EXPLANATION +
+      RETRIEVED_CONTEXT_EXPLANATION;
+    const systemPromptTokens =
+      await this.chatModel.countTokens(maxSystemPrompt);
+
+    const currentMsgTokens =
+      await this.chatModel.countTokens(currentUserMessage);
+
+    let availableBudget =
+      this.maxContextTokens - systemPromptTokens - currentMsgTokens;
+
+    const currentContextTokens = currentContext?.totalTokens ?? 0;
+    availableBudget -= currentContextTokens;
+
+    const includedTurns: Array<{
+      turn: ChatTurn;
+      includeContext: boolean;
+      tokens: number;
+    }> = [];
+
+    for (let i = this.history.length - 1; i >= 0; i--) {
+      const turn = this.history[i];
+      const turnMsgTokens = await this.estimateTurnTokens(turn);
+      const turnContextTokens = turn.context?.totalTokens ?? 0;
+
+      if (availableBudget >= turnMsgTokens + turnContextTokens) {
+        includedTurns.unshift({
+          turn,
+          includeContext: true,
+          tokens: turnMsgTokens + turnContextTokens,
+        });
+        availableBudget -= turnMsgTokens + turnContextTokens;
+      } else if (availableBudget >= turnMsgTokens) {
+        includedTurns.unshift({
+          turn,
+          includeContext: false,
+          tokens: turnMsgTokens,
+        });
+        availableBudget -= turnMsgTokens;
+      } else {
+        this.log(`Trimming ${i + 1} older turns due to context window limit`);
+        break;
+      }
+    }
+
+    const contextsToInclude: string[] = [];
+    for (const { turn, includeContext } of includedTurns) {
+      if (includeContext && turn.context?.formattedContext) {
+        contextsToInclude.push(turn.context.formattedContext);
+      }
+    }
+    if (currentContext?.formattedContext) {
+      contextsToInclude.push(currentContext.formattedContext);
+    }
+
+    const formattedExplicitRefs =
+      explicitRefs && explicitRefs.length > 0
+        ? this.contextBuilder.formatExplicitReferences(explicitRefs)
+        : '';
+
+    const hasExplicitRefs = formattedExplicitRefs.length > 0;
+    const hasRetrievedContext = contextsToInclude.length > 0;
+    const hasAnyContext = hasExplicitRefs || hasRetrievedContext;
+
+    let systemContent = hasAnyContext
+      ? SYSTEM_PROMPT_WITH_CONTEXT_INTRO
+      : SYSTEM_PROMPT_BASE;
+
+    if (hasExplicitRefs) {
+      systemContent += `\n\n${EXPLICIT_REFS_EXPLANATION}`;
+    }
+    if (hasRetrievedContext) {
+      systemContent += `\n\n${RETRIEVED_CONTEXT_EXPLANATION}`;
+    }
+
+    if (hasExplicitRefs) {
+      systemContent += `\n\n[Explicit References]\n${formattedExplicitRefs}`;
+    }
+
+    if (hasRetrievedContext) {
+      systemContent += `\n\n[Context]\n${contextsToInclude.join('\n\n')}`;
+    }
+
+    const messages: ChatMessage[] = [];
+    messages.push({ role: 'system', content: systemContent });
+
+    for (const { turn } of includedTurns) {
+      messages.push({ role: 'user', content: turn.userMessage });
+      messages.push({ role: 'assistant', content: turn.assistantMessage });
+    }
+
+    messages.push({ role: 'user', content: currentUserMessage });
+
+    const explicitRefsCount = explicitRefs?.length ?? 0;
+    this.log(
+      `Built messages: ${includedTurns.length}/${this.history.length} turns, ${contextsToInclude.length} contexts, ${explicitRefsCount} explicit refs`
+    );
+
+    return messages;
+  }
+
+  /**
+   * Estimate token count for a turn
+   */
+  private async estimateTurnTokens(turn: ChatTurn): Promise<number> {
+    const msgTokens = await this.chatModel.countTokens(
+      turn.userMessage + turn.assistantMessage
+    );
+    return msgTokens;
+  }
+
+  /**
+   * Send a message and stream the response
+   */
+  async chatStream(
+    userMessage: string,
+    onDelta: (delta: ChatStreamDelta) => void,
+    onContextReady?: () => void,
+    signal?: AbortSignal
+  ): Promise<string> {
+    this.log(`Received message (streaming): "${userMessage.slice(0, 50)}..."`);
+
+    const explicitRefs =
+      await this.contextBuilder.getExplicitReferences(userMessage);
+
+    let turnContext: ChatContext | undefined;
+
+    if (this.configManager.get('ragEnableContext')) {
+      const tokenBudget = this.configManager.get('ragContextTokenBudget');
+      turnContext = await this.contextBuilder.buildContext(
+        userMessage,
+        tokenBudget
+      );
+      this.log(
+        `Built context with ${turnContext.chunks.length} chunks, ${turnContext.totalTokens} tokens`
+      );
+    }
+
+    onContextReady?.();
+
+    const messages = await this.buildMessages(
+      userMessage,
+      turnContext,
+      explicitRefs
+    );
+    const maxTokens = this.configManager.get('chatMaxTokens');
+    const enableThinking = this.configManager.get('chatEnableThinking');
+
+    let fullResponse = '';
+    const usage = await this.chatModel.chatStream(
+      messages,
+      {
+        maxTokens,
+        idSlot: this.slotId,
+        enableThinking,
+      },
+      delta => {
+        fullResponse += delta.content;
+        onDelta(delta);
+      },
+      undefined,
+      signal
+    );
+
+    this.log(
+      `Streaming complete: ${usage.totalTokens} tokens (prompt: ${usage.promptTokens}, completion: ${usage.completionTokens})`
+    );
+
+    this.history.push({
+      userMessage,
+      assistantMessage: fullResponse,
+      context: turnContext,
+      explicitRefs: explicitRefs.length > 0 ? explicitRefs : undefined,
+    });
+
+    return fullResponse;
+  }
+
+  /**
+   * Get conversation history
+   */
+  getHistory(): ChatTurn[] {
+    return [...this.history];
+  }
+
+  /**
+   * Delete a specific turn from history
+   */
+  deleteTurn(index: number): void {
+    if (index < 0 || index >= this.history.length) {
+      this.warn(`Invalid turn index: ${index}`);
+      return;
+    }
+    this.log(`Deleting turn at index ${index}`);
+    this.history.splice(index, 1);
+  }
+
+  /**
+   * Truncate history to a specific index (exclusive)
+   */
+  truncateHistory(fromIndex: number): void {
+    if (fromIndex < 0 || fromIndex > this.history.length) {
+      this.warn(`Invalid truncate index: ${fromIndex}`);
+      return;
+    }
+    this.log(`Truncating history from index ${fromIndex}`);
+    this.history = this.history.slice(0, fromIndex);
+  }
+
+  /**
+   * Clear conversation history
+   */
+  clear(): void {
+    this.log('Clearing conversation');
+    this.history = [];
+  }
+
+  /**
+   * Check if chat model is ready
+   */
+  isReady(): boolean {
+    return this.chatModel.isReady();
+  }
+}

--- a/src/ChatContextBuilder.ts
+++ b/src/ChatContextBuilder.ts
@@ -1,0 +1,304 @@
+import type { SearchManager, ChunkResult } from './SearchManager';
+import type { LlamaCppChat } from './LlamaCppChat';
+import type { ConfigManager } from './ConfigManager';
+import type { MetadataStore } from './MetadataStore';
+import { WithLogging } from './WithLogging';
+
+/**
+ * Context chunk with provenance information
+ */
+export interface ContextChunk {
+  content: string;
+  filePath: string;
+  title: string;
+  heading: string | null;
+  tokenCount: number;
+}
+
+/**
+ * Built context ready for LLM consumption
+ */
+export interface ChatContext {
+  chunks: ContextChunk[];
+  formattedContext: string;
+  totalTokens: number;
+}
+
+/**
+ * Explicit reference from user input [[wikilink]]
+ */
+export interface ExplicitReference {
+  wikilink: string;
+  filePath: string;
+  content: string;
+}
+
+/**
+ * Builds chat context from search results and explicit references
+ */
+export class ChatContextBuilder extends WithLogging {
+  protected readonly componentName = 'ChatContextBuilder';
+
+  constructor(
+    private searchManager: SearchManager,
+    private chatModel: LlamaCppChat,
+    private metadataStore: MetadataStore,
+    protected configManager: ConfigManager
+  ) {
+    super();
+  }
+
+  /**
+   * Build context for a query within token budget
+   * @param query User's query
+   * @param tokenBudget Maximum tokens to use for context
+   * @param maxChunks Maximum number of chunks to include (default: 10)
+   * @returns Chat context with formatted string and metadata
+   */
+  async buildContext(
+    query: string,
+    tokenBudget: number,
+    maxChunks: number = 10
+  ): Promise<ChatContext> {
+    this.log(`Building context for query: "${query.slice(0, 50)}..."`);
+
+    const chunks = await this.retrieveChunks(query, maxChunks);
+    if (chunks.length === 0) {
+      this.log('No relevant chunks found');
+      return { chunks: [], formattedContext: '', totalTokens: 0 };
+    }
+
+    this.log(`Retrieved ${chunks.length} chunks, fitting to token budget`);
+    return this.buildContextWithBudget(chunks, tokenBudget);
+  }
+
+  /**
+   * Retrieve relevant chunks using hybrid search + reranking
+   */
+  private async retrieveChunks(
+    query: string,
+    maxChunks: number
+  ): Promise<ChunkResult[]> {
+    const chunks = await this.searchManager.getRerankedChunksForRAG(
+      query,
+      maxChunks
+    );
+
+    if (chunks === null) {
+      this.warn('Reranker not ready, context unavailable');
+      return [];
+    }
+
+    return chunks;
+  }
+
+  /**
+   * Build context string within token budget
+   */
+  private async buildContextWithBudget(
+    chunks: ChunkResult[],
+    tokenBudget: number
+  ): Promise<ChatContext> {
+    const contextChunks: ContextChunk[] = [];
+    let totalTokens = 0;
+
+    for (const chunk of chunks) {
+      const heading = this.extractHeading(chunk.metadata.headings);
+      const formatted = this.formatChunk(
+        chunk.content,
+        chunk.metadata.title,
+        heading,
+        chunk.filePath
+      );
+
+      const tokenCount = await this.chatModel.countTokens(formatted);
+
+      if (totalTokens + tokenCount > tokenBudget) {
+        this.log(
+          `Token budget reached at ${contextChunks.length} chunks (${totalTokens} tokens)`
+        );
+        break;
+      }
+
+      contextChunks.push({
+        content: chunk.content,
+        filePath: chunk.filePath,
+        title: chunk.metadata.title,
+        heading,
+        tokenCount,
+      });
+      totalTokens += tokenCount;
+    }
+
+    const formattedContext = contextChunks
+      .map(c => this.formatChunk(c.content, c.title, c.heading, c.filePath))
+      .join('\n\n');
+
+    this.log(
+      `Built context with ${contextChunks.length} chunks, ${totalTokens} tokens`
+    );
+
+    return {
+      chunks: contextChunks,
+      formattedContext,
+      totalTokens,
+    };
+  }
+
+  /**
+   * Extract the most specific heading from the headings array
+   */
+  private extractHeading(headings: string[]): string | null {
+    if (!headings || headings.length === 0) {
+      return null;
+    }
+    return headings[headings.length - 1];
+  }
+
+  /**
+   * Format a chunk with provenance information
+   */
+  private formatChunk(
+    content: string,
+    title: string,
+    heading: string | null,
+    filePath?: string
+  ): string {
+    const linkText = this.getWikilinkText(title, filePath);
+    const wikilink = heading
+      ? `[[${linkText}#${this.stripHeadingPrefix(heading)}]]`
+      : `[[${linkText}]]`;
+
+    return `${wikilink}\n${content}`;
+  }
+
+  /**
+   * Strip markdown heading prefix (e.g., "## Heading" -> "Heading")
+   */
+  private stripHeadingPrefix(heading: string): string {
+    return heading.replace(/^#+\s*/, '');
+  }
+
+  /**
+   * Get the appropriate text for a wikilink
+   */
+  private getWikilinkText(title: string, filePath?: string): string {
+    if (!filePath) return title;
+
+    const isMarkdown = filePath.toLowerCase().endsWith('.md');
+    if (isMarkdown) {
+      return title;
+    }
+
+    const parts = filePath.split('/');
+    return parts[parts.length - 1];
+  }
+
+  /**
+   * Format explicit references for the system prompt
+   */
+  formatExplicitReferences(refs: ExplicitReference[]): string {
+    if (refs.length === 0) return '';
+    return refs
+      .map(ref => {
+        const linkText = this.getWikilinkText(ref.wikilink, ref.filePath);
+        return `[[${linkText}]]\n${ref.content}`;
+      })
+      .join('\n\n');
+  }
+
+  /**
+   * Parse wikilinks from a message
+   */
+  private parseWikilinks(message: string): string[] {
+    const regex = /\[\[([^\]]+)\]\]/g;
+    const matches: string[] = [];
+    let match;
+    while ((match = regex.exec(message)) !== null) {
+      matches.push(match[1]);
+    }
+    return matches;
+  }
+
+  /**
+   * Build file path lookup map from MetadataStore
+   */
+  private async buildFilePathMap(): Promise<Map<string, string>> {
+    const chunks = await this.metadataStore.getAllChunks();
+    const map = new Map<string, string>();
+    const seenPaths = new Set<string>();
+
+    for (const chunk of chunks) {
+      const filePath = chunk.filePath;
+      if (seenPaths.has(filePath)) {
+        continue;
+      }
+      seenPaths.add(filePath);
+
+      const parts = filePath.split('/');
+      const filenameWithExt = parts[parts.length - 1];
+      const filenameNoExt = filenameWithExt.replace(/\.md$/, '');
+
+      map.set(filePath, filePath);
+      map.set(filenameWithExt, filePath);
+      if (filenameWithExt !== filenameNoExt) {
+        map.set(filenameNoExt, filePath);
+      }
+    }
+
+    return map;
+  }
+
+  /**
+   * Resolve a wikilink to a file path
+   */
+  private async resolveWikilink(wikilink: string): Promise<string | null> {
+    const map = await this.buildFilePathMap();
+    const linkWithoutSection = wikilink.split('#')[0];
+
+    if (map.has(linkWithoutSection)) {
+      return map.get(linkWithoutSection)!;
+    }
+
+    const lowerLink = linkWithoutSection.toLowerCase();
+    for (const [key, value] of map.entries()) {
+      if (key.toLowerCase() === lowerLink) {
+        return value;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Get content for explicit references in user message
+   */
+  async getExplicitReferences(message: string): Promise<ExplicitReference[]> {
+    const wikilinks = this.parseWikilinks(message);
+    if (wikilinks.length === 0) {
+      return [];
+    }
+
+    const refs: ExplicitReference[] = [];
+    for (const wikilink of wikilinks) {
+      const filePath = await this.resolveWikilink(wikilink);
+      if (!filePath) {
+        this.warn(`Could not resolve wikilink: [[${wikilink}]]`);
+        continue;
+      }
+
+      const chunks = await this.metadataStore.getChunksByFile(filePath);
+      if (chunks.length === 0) {
+        this.warn(`No content found for: ${filePath}`);
+        continue;
+      }
+
+      chunks.sort((a, b) => a.id.localeCompare(b.id));
+      const content = chunks.map(c => c.content).join('\n\n');
+      refs.push({ wikilink, filePath, content });
+    }
+
+    this.log(`Resolved ${refs.length}/${wikilinks.length} explicit references`);
+    return refs;
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,16 @@ export interface SonarSettings {
   chatTopP: number; // Top-p (nucleus sampling) for response generation (default: 0.9)
   chatPresencePenalty: number; // Presence penalty to reduce repetition (default: 0.5)
 
+  // Chat configuration
+  // ==================
+  chatMaxTokens: number; // Maximum tokens for response generation
+  chatEnableThinking: boolean; // Enable thinking mode for Qwen3 (default: false)
+
+  // RAG configuration
+  // =================
+  ragEnableContext: boolean; // Enable context retrieval from vault (default: true)
+  ragContextTokenBudget: number; // Maximum tokens for RAG context
+
   // Search parameters
   // =================
   bm25AggMethod: AggregationMethod; // BM25 aggregation method (default: 'max_p')
@@ -127,6 +137,16 @@ export const DEFAULT_SETTINGS: SonarSettings = {
   chatTopK: 0,
   chatTopP: 0.9,
   chatPresencePenalty: 0.5,
+
+  // Chat configuration
+  // ==================
+  chatMaxTokens: 8192,
+  chatEnableThinking: false,
+
+  // RAG configuration
+  // =================
+  ragEnableContext: true,
+  ragContextTokenBudget: 4096,
 
   // Search parameters
   // =================

--- a/src/ui/ChatView.ts
+++ b/src/ui/ChatView.ts
@@ -1,0 +1,481 @@
+import { HoverPopover, ItemView, TFile, WorkspaceLeaf } from 'obsidian';
+import { mount, unmount } from 'svelte';
+import { writable, get } from 'svelte/store';
+import type { ConfigManager } from '../ConfigManager';
+import type { ChatTurn } from '../Chat';
+import { createComponentLogger, type ComponentLogger } from '../WithLogging';
+import ChatViewContent from './ChatViewContent.svelte';
+import { FileSuggestModal, getWikilinkForFile } from './FileSuggestModal';
+import type SonarPlugin from '../../main';
+
+export const CHAT_VIEW_TYPE = 'chat-view';
+
+/**
+ * Check if keyboard event matches the send shortcut (Cmd+Ctrl+Enter)
+ */
+export function isSendShortcut(e: KeyboardEvent): boolean {
+  return e.key === 'Enter' && e.metaKey && e.ctrlKey && !e.isComposing;
+}
+
+export type ChatViewStatus = 'initializing' | 'ready' | 'processing' | 'error';
+
+type ProcessingPhase = 'retrieving' | 'generating';
+
+interface ChatViewState {
+  status: ChatViewStatus;
+  history: ChatTurn[];
+  errorMessage: string | null;
+  streamingContent: string;
+  pendingUserMessage: string | null;
+  enableContext: boolean;
+  enableThinking: boolean;
+  processingPhase: ProcessingPhase | null;
+  modelName: string;
+}
+
+const COMPONENT_ID = 'ChatView';
+
+export class ChatView extends ItemView {
+  private plugin: SonarPlugin;
+  private configManager: ConfigManager;
+  private logger: ComponentLogger;
+  private svelteComponent: ReturnType<typeof mount> | null = null;
+  hoverPopover: HoverPopover | null = null; // HoverParent interface
+  private abortController: AbortController | null = null;
+
+  private chatViewStore = writable<ChatViewState>({
+    status: 'initializing',
+    history: [],
+    errorMessage: null,
+    streamingContent: '',
+    pendingUserMessage: null,
+    enableContext: true,
+    enableThinking: false,
+    processingPhase: null,
+    modelName: '',
+  });
+
+  constructor(
+    leaf: WorkspaceLeaf,
+    plugin: SonarPlugin,
+    configManager: ConfigManager
+  ) {
+    super(leaf);
+    this.plugin = plugin;
+    this.configManager = configManager;
+    this.logger = createComponentLogger(configManager, COMPONENT_ID);
+  }
+
+  getViewType(): string {
+    return CHAT_VIEW_TYPE;
+  }
+
+  getDisplayText(): string {
+    return 'Chat';
+  }
+
+  getIcon(): string {
+    return 'message-circle';
+  }
+
+  /**
+   * Extract a short model name from the config
+   * e.g., 'qwen3-8b-q8_0.gguf' -> 'Qwen3-8B'
+   */
+  private getShortModelName(): string {
+    const modelFile = this.configManager.get('llamaChatModelFile');
+    // Remove .gguf extension and quantization suffix (e.g., -q8_0, -Q4_K_M)
+    const baseName = modelFile
+      .replace(/\.gguf$/i, '')
+      .replace(/[-_][qQ]\d+[_]?\d*[_]?[a-zA-Z]*$/i, '');
+    // Capitalize first letter of each segment for readability
+    return baseName
+      .split('-')
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join('-');
+  }
+
+  async onOpen(): Promise<void> {
+    this.contentEl.empty();
+    this.contentEl.addClass('rag-view-container');
+
+    this.updateStore({
+      enableContext: this.configManager.get('ragEnableContext'),
+      enableThinking: this.configManager.get('chatEnableThinking'),
+      modelName: this.getShortModelName(),
+    });
+
+    this.mountComponent();
+    this.createInputArea();
+    this.registerKeyboardShortcuts();
+
+    // Lazy-load chat model when view is opened
+    const result = await this.plugin.initializeChatModelLazy();
+    if (result === 'ready') {
+      this.updateStore({ status: 'ready' });
+    } else if (result === 'failed') {
+      this.updateStore({
+        status: 'error',
+        errorMessage: 'Failed to initialize chat model',
+      });
+    }
+    // If 'pending', keep 'initializing' state and wait for onSonarInitialized
+  }
+
+  private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
+
+  private registerKeyboardShortcuts(): void {
+    // Cmd+Ctrl+Enter to send (Cmd+Enter alone is captured by Obsidian on Mac)
+    this.keydownHandler = (e: KeyboardEvent) => {
+      if (
+        isSendShortcut(e) &&
+        this.inputEl &&
+        document.activeElement === this.inputEl
+      ) {
+        e.preventDefault();
+        this.submitMessage();
+      }
+    };
+    document.addEventListener('keydown', this.keydownHandler, {
+      capture: true,
+    });
+  }
+
+  private unregisterKeyboardShortcuts(): void {
+    if (this.keydownHandler) {
+      document.removeEventListener('keydown', this.keydownHandler, {
+        capture: true,
+      });
+      this.keydownHandler = null;
+    }
+  }
+
+  private mountComponent(): void {
+    const messagesContainer = this.contentEl.createDiv('rag-messages-wrapper');
+
+    this.svelteComponent = mount(ChatViewContent, {
+      target: messagesContainer,
+      props: {
+        app: this.app,
+        configManager: this.configManager,
+        store: this.chatViewStore,
+        onClearHistory: () => this.handleClearHistory(),
+        onToggleContext: () => this.handleToggleContext(),
+        onToggleThinking: () => this.handleToggleThinking(),
+        onHoverLink: (event: MouseEvent, linktext: string) =>
+          this.handleHoverLink(event, linktext),
+        onDeleteTurn: (index: number) => this.handleDeleteTurn(index),
+        onEditTurn: (index: number, message: string) =>
+          this.handleEditTurn(index, message),
+      },
+    });
+  }
+
+  private handleToggleContext(): void {
+    const currentValue = this.configManager.get('ragEnableContext');
+    const newValue = !currentValue;
+    this.configManager.set('ragEnableContext', newValue);
+    this.updateStore({ enableContext: newValue });
+  }
+
+  private handleToggleThinking(): void {
+    const currentValue = this.configManager.get('chatEnableThinking');
+    const newValue = !currentValue;
+    this.configManager.set('chatEnableThinking', newValue);
+    this.updateStore({ enableThinking: newValue });
+  }
+
+  private handleCancel(): void {
+    if (this.abortController) {
+      this.logger.log('Cancelling generation...');
+      this.abortController.abort();
+      this.abortController = null;
+    }
+  }
+
+  private handleHoverLink(event: MouseEvent, linktext: string): void {
+    this.app.workspace.trigger('hover-link', {
+      event,
+      source: CHAT_VIEW_TYPE,
+      hoverParent: this,
+      targetEl: event.target as HTMLElement,
+      linktext,
+      sourcePath: '',
+    });
+  }
+
+  private inputEl: HTMLTextAreaElement | null = null;
+  private sendButton: HTMLButtonElement | null = null;
+  private storeUnsubscribe: (() => void) | null = null;
+
+  private createInputArea(): void {
+    const inputContainer = this.contentEl.createDiv('rag-input-container');
+
+    this.inputEl = document.createElement('textarea');
+    this.inputEl.className = 'rag-message-input';
+    this.inputEl.rows = 1;
+
+    // Auto-resize textarea based on content and detect wikilink trigger
+    this.inputEl.addEventListener('input', e => {
+      if (!this.inputEl) return;
+
+      this.inputEl.style.height = 'auto';
+      this.inputEl.style.height = `${this.inputEl.scrollHeight}px`;
+
+      // Detect `[[` trigger for file autocomplete
+      if ((e as InputEvent).data === '[') {
+        const cursorPos = this.inputEl.selectionStart;
+        const textBefore = this.inputEl.value.slice(0, cursorPos);
+        if (textBefore.endsWith('[[')) {
+          this.openFileSuggestModal();
+        }
+      }
+    });
+
+    inputContainer.appendChild(this.inputEl);
+
+    this.sendButton = inputContainer.createEl('button', {
+      cls: 'rag-send-button',
+    });
+    this.sendButton.textContent = 'Send';
+    this.sendButton.addEventListener('click', () => {
+      const currentState = get(this.chatViewStore);
+      if (currentState.status === 'processing') {
+        this.handleCancel();
+      } else {
+        this.submitMessage();
+      }
+    });
+
+    // Subscribe to store to update button and placeholder state
+    this.storeUnsubscribe = this.chatViewStore.subscribe(state => {
+      if (this.sendButton) {
+        const isProcessing = state.status === 'processing';
+        this.sendButton.textContent = isProcessing ? '' : 'Send';
+        this.sendButton.classList.toggle('is-loading', isProcessing);
+      }
+      if (this.inputEl) {
+        this.inputEl.placeholder = state.enableContext
+          ? 'Ask about your notes... (Cmd+Ctrl+Enter to send)'
+          : 'Ask a question... (Cmd+Ctrl+Enter to send)';
+      }
+    });
+  }
+
+  private async openFileSuggestModal(): Promise<void> {
+    if (!this.plugin.metadataStore) {
+      this.logger.warn('MetadataStore not available for file suggestions');
+      return;
+    }
+
+    // Get unique file paths from indexed chunks
+    const chunks = await this.plugin.metadataStore.getAllChunks();
+    const filePaths = new Set<string>();
+    for (const chunk of chunks) {
+      filePaths.add(chunk.filePath);
+    }
+
+    // Convert to TFile objects
+    const files: TFile[] = [];
+    for (const path of filePaths) {
+      const file = this.app.vault.getAbstractFileByPath(path);
+      if (file instanceof TFile) {
+        files.push(file);
+      }
+    }
+
+    if (files.length === 0) {
+      this.logger.warn('No indexed files found for suggestions');
+      return;
+    }
+
+    new FileSuggestModal(this.app, files, file => {
+      this.insertWikilink(file);
+    }).open();
+  }
+
+  private insertWikilink(file: TFile): void {
+    if (!this.inputEl) return;
+
+    const wikilink = getWikilinkForFile(file);
+    const cursorPos = this.inputEl.selectionStart;
+    const textBefore = this.inputEl.value.slice(0, cursorPos);
+    const textAfter = this.inputEl.value.slice(cursorPos);
+
+    // Insert file name and closing brackets
+    this.inputEl.value = textBefore + wikilink + ']]' + textAfter;
+
+    // Move cursor after the closing brackets
+    const newPos = cursorPos + wikilink.length + 2;
+    this.inputEl.setSelectionRange(newPos, newPos);
+    this.inputEl.focus();
+  }
+
+  private submitMessage(): void {
+    if (!this.inputEl) return;
+    // Prevent sending during processing
+    const currentState = get(this.chatViewStore);
+    if (currentState.status === 'processing') return;
+
+    const message = this.inputEl.value.trim();
+    if (message) {
+      this.handleSendMessage(message);
+      this.inputEl.value = '';
+      this.inputEl.style.height = 'auto';
+    }
+  }
+
+  private updateStore(partialState: Partial<ChatViewState>): void {
+    const currentState = get(this.chatViewStore);
+    this.chatViewStore.set({ ...currentState, ...partialState });
+  }
+
+  private async handleSendMessage(message: string): Promise<void> {
+    if (!this.plugin.chat) {
+      this.logger.error('Chat not initialized');
+      this.updateStore({
+        status: 'error',
+        errorMessage: 'Chat not initialized',
+      });
+      return;
+    }
+
+    const enableContext = this.configManager.get('ragEnableContext');
+    const initialPhase: ProcessingPhase = enableContext
+      ? 'retrieving'
+      : 'generating';
+
+    this.abortController = new AbortController();
+
+    this.updateStore({
+      status: 'processing',
+      streamingContent: '',
+      pendingUserMessage: message,
+      processingPhase: initialPhase,
+      errorMessage: null,
+    });
+
+    try {
+      await this.plugin.chat.chatStream(
+        message,
+        delta => {
+          const currentState = get(this.chatViewStore);
+          this.updateStore({
+            streamingContent: currentState.streamingContent + delta.content,
+          });
+        },
+        () => {
+          this.updateStore({ processingPhase: 'generating' });
+        },
+        this.abortController.signal
+      );
+
+      this.updateStore({
+        status: 'ready',
+        history: this.plugin.chat.getHistory(),
+        errorMessage: null,
+        streamingContent: '',
+        pendingUserMessage: null,
+        processingPhase: null,
+      });
+    } catch (error) {
+      // Don't show error for user-initiated abort
+      if (error instanceof Error && error.name === 'AbortError') {
+        // Restore user message to input for re-editing (like edit behavior)
+        const cancelledMessage = get(this.chatViewStore).pendingUserMessage;
+        this.updateStore({
+          status: 'ready',
+          errorMessage: null,
+          streamingContent: '',
+          pendingUserMessage: null,
+          processingPhase: null,
+        });
+        if (this.inputEl && cancelledMessage) {
+          this.inputEl.value = cancelledMessage;
+          this.inputEl.style.height = 'auto';
+          this.inputEl.style.height = `${this.inputEl.scrollHeight}px`;
+          this.inputEl.focus();
+        }
+        return;
+      }
+
+      this.logger.error(`Chat error: ${error}`);
+      this.updateStore({
+        status: 'error',
+        errorMessage: error instanceof Error ? error.message : 'Unknown error',
+        streamingContent: '',
+        pendingUserMessage: null,
+        processingPhase: null,
+      });
+    } finally {
+      this.abortController = null;
+    }
+  }
+
+  private handleClearHistory(): void {
+    if (this.plugin.chat) {
+      this.plugin.chat.clear();
+      this.updateStore({
+        history: [],
+        errorMessage: null,
+      });
+    }
+  }
+
+  private handleDeleteTurn(index: number): void {
+    if (this.plugin.chat) {
+      this.plugin.chat.deleteTurn(index);
+      this.updateStore({
+        history: this.plugin.chat.getHistory(),
+      });
+    }
+  }
+
+  private handleEditTurn(index: number, message: string): void {
+    if (!this.plugin.chat) return;
+    // Truncate history to the turn being edited
+    this.plugin.chat.truncateHistory(index);
+    this.updateStore({
+      history: this.plugin.chat.getHistory(),
+    });
+    this.handleSendMessage(message);
+  }
+
+  async onSonarInitialized(): Promise<void> {
+    const currentState = get(this.chatViewStore);
+    // Retry lazy init if view was opened before Sonar finished initializing
+    if (currentState.status === 'initializing') {
+      const result = await this.plugin.initializeChatModelLazy();
+      switch (result) {
+        case 'ready':
+          this.updateStore({ status: 'ready', errorMessage: null });
+          break;
+        case 'failed':
+          this.updateStore({
+            status: 'error',
+            errorMessage: 'Failed to initialize chat model',
+          });
+          break;
+        case 'pending':
+          throw new Error(
+            'Unexpected pending state: Sonar should be initialized at this point'
+          );
+      }
+    }
+  }
+
+  async onClose(): Promise<void> {
+    this.unregisterKeyboardShortcuts();
+    if (this.storeUnsubscribe) {
+      this.storeUnsubscribe();
+      this.storeUnsubscribe = null;
+    }
+    if (this.svelteComponent) {
+      unmount(this.svelteComponent);
+      this.svelteComponent = null;
+    }
+
+    // Cleanup chat model to free memory
+    await this.plugin.cleanupChatModel();
+  }
+}

--- a/src/ui/ChatViewContent.svelte
+++ b/src/ui/ChatViewContent.svelte
@@ -1,0 +1,723 @@
+<script lang="ts">
+  import { App, Notice } from 'obsidian';
+  import type { Writable } from 'svelte/store';
+  import type { ConfigManager } from '../ConfigManager';
+  import type { ChatTurn } from '../Chat';
+  import { MarkdownRenderingManager } from './MarkdownRenderingManager';
+  import { isSendShortcut } from './ChatView';
+  import { onDestroy, tick } from 'svelte';
+  import { Copy, Pencil, Trash2, createElement } from 'lucide';
+
+  interface ChatViewState {
+    status: 'initializing' | 'ready' | 'processing' | 'error';
+    history: ChatTurn[];
+    errorMessage: string | null;
+    streamingContent: string;
+    pendingUserMessage: string | null;
+    enableContext: boolean;
+    enableThinking: boolean;
+    processingPhase: 'retrieving' | 'generating' | null;
+    modelName: string;
+  }
+
+  interface Props {
+    app: App;
+    configManager: ConfigManager;
+    store: Writable<ChatViewState>;
+    onClearHistory: () => void;
+    onToggleContext: () => void;
+    onToggleThinking: () => void;
+    onHoverLink: (event: MouseEvent, linktext: string) => void;
+    onDeleteTurn: (index: number) => void;
+    onEditTurn: (index: number, message: string) => void;
+  }
+
+  let { app, configManager, store, onClearHistory, onToggleContext, onToggleThinking, onHoverLink, onDeleteTurn, onEditTurn }: Props = $props();
+
+  let editingIndex = $state<number | null>(null);
+  let editingText = $state('');
+
+  let messagesContainer: HTMLElement;
+
+  // Use a different class from SemanticNoteFinder's 'result-excerpt-markdown'
+  // to avoid inheriting its margin-resetting styles
+  const markdownManager = new MarkdownRenderingManager(app, configManager, {
+    cssClass: 'chat-result-excerpt-markdown',
+  });
+
+  onDestroy(() => {
+    markdownManager.cleanup();
+  });
+
+  function setMessageElement(node: HTMLElement, content: string) {
+    function render(text: string) {
+      requestAnimationFrame(() => {
+        if (node.parentElement) {
+          node.empty();
+          markdownManager.render(text, node, '');
+        }
+      });
+    }
+    render(content);
+    return {
+      update(newContent: string) {
+        render(newContent);
+      },
+      destroy() {
+        markdownManager.cleanupElement(node);
+      },
+    };
+  }
+
+  function setupInternalLinkHandler(node: HTMLElement) {
+    function handleClick(event: MouseEvent) {
+      const target = event.target as HTMLElement;
+      const link = target.closest('a.internal-link');
+      if (link) {
+        event.preventDefault();
+        const href = link.getAttribute('href');
+        if (href) {
+          app.workspace.openLinkText(href, '', false);
+        }
+      }
+    }
+
+    function handleMouseover(event: MouseEvent) {
+      const target = event.target as HTMLElement;
+      const link = target.closest('a.internal-link');
+      if (link) {
+        const href = link.getAttribute('href');
+        if (href) {
+          onHoverLink(event, href);
+        }
+      }
+    }
+
+    node.addEventListener('click', handleClick);
+    node.addEventListener('mouseover', handleMouseover);
+    return {
+      destroy() {
+        node.removeEventListener('click', handleClick);
+        node.removeEventListener('mouseover', handleMouseover);
+      },
+    };
+  }
+
+  let autoScrollEnabled = $state(true);
+
+  function isAtBottom(): boolean {
+    if (!messagesContainer) return true;
+    const threshold = 20;
+    return messagesContainer.scrollHeight - messagesContainer.scrollTop - messagesContainer.clientHeight < threshold;
+  }
+
+  function scrollToBottom() {
+    if (messagesContainer) {
+      messagesContainer.scrollTop = messagesContainer.scrollHeight;
+    }
+  }
+
+  function handleScroll() {
+    autoScrollEnabled = isAtBottom();
+  }
+
+  // Preserve scroll position across status transitions
+  let prevStatus: string | null = null;
+
+  // Before DOM updates: save scroll position and schedule restoration
+  $effect.pre(() => {
+    const currentStatus = $store.status;
+    if (prevStatus === 'processing' && currentStatus === 'ready' && !autoScrollEnabled) {
+      const scrollTop = messagesContainer?.scrollTop;
+      if (scrollTop !== undefined) {
+        // Schedule scroll restoration after DOM updates
+        tick().then(() => {
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              if (messagesContainer) {
+                messagesContainer.scrollTop = scrollTop;
+              }
+            });
+          });
+        });
+      }
+    }
+    prevStatus = currentStatus;
+  });
+
+  $effect(() => {
+    // Auto-scroll only during streaming, not after generation completes
+    if ($store.streamingContent && autoScrollEnabled) {
+      setTimeout(scrollToBottom, 0);
+    }
+  });
+
+  function getStatusText(status: ChatViewState['status']): string {
+    switch (status) {
+      case 'initializing':
+        return 'Initializing...';
+      case 'processing':
+        return 'Thinking...';
+      case 'error':
+        return 'Error';
+      default:
+        return '';
+    }
+  }
+
+  function setupIcon(node: HTMLElement, IconComponent: typeof Copy) {
+    const icon = createElement(IconComponent);
+    icon.setAttribute('width', '14');
+    icon.setAttribute('height', '14');
+    node.appendChild(icon);
+  }
+
+  async function handleCopy(text: string) {
+    await navigator.clipboard.writeText(text);
+    new Notice('Copied to clipboard');
+  }
+
+  function handleDelete(index: number) {
+    onDeleteTurn(index);
+  }
+
+  function startEditing(index: number, text: string) {
+    editingIndex = index;
+    editingText = text;
+  }
+
+  function cancelEditing() {
+    editingIndex = null;
+    editingText = '';
+  }
+
+  function submitEdit(index: number) {
+    if (editingText.trim()) {
+      onEditTurn(index, editingText.trim());
+    }
+    editingIndex = null;
+    editingText = '';
+  }
+
+  function handleEditKeydown(event: KeyboardEvent, index: number) {
+    if (isSendShortcut(event)) {
+      event.preventDefault();
+      submitEdit(index);
+    } else if (event.key === 'Escape') {
+      cancelEditing();
+    }
+  }
+</script>
+
+<div class="rag-view">
+  <div class="rag-header">
+    <div class="header-title">
+      {#if $store.modelName}
+        <h3 class="model-name">{$store.modelName}</h3>
+      {/if}
+    </div>
+    <div class="header-controls">
+      <button
+        class="context-toggle"
+        class:active={$store.enableContext}
+        onclick={onToggleContext}
+        title={$store.enableContext ? 'Context retrieval enabled' : 'Context retrieval disabled'}
+      >
+        RAG
+      </button>
+      <button
+        class="context-toggle"
+        class:active={$store.enableThinking}
+        onclick={onToggleThinking}
+        title={$store.enableThinking ? 'Thinking mode enabled' : 'Thinking mode disabled'}
+      >
+        Think
+      </button>
+      {#if $store.history.length > 0}
+        <button
+          class="clear-button"
+          onclick={onClearHistory}
+          title="Clear conversation"
+        >
+          Clear
+        </button>
+      {/if}
+    </div>
+  </div>
+
+  <div
+    class="messages-container"
+    bind:this={messagesContainer}
+    use:setupInternalLinkHandler
+    onscroll={handleScroll}
+    role="log"
+  >
+    {#if $store.history.length === 0 && !$store.pendingUserMessage}
+      <div class="empty-state">
+        {#if $store.status === 'initializing'}
+          <p class="thinking-indicator">Initializing...</p>
+          <p class="hint">Waiting for chat model to load.</p>
+        {:else if $store.enableContext}
+          <p>Ask a question about your notes.</p>
+          <p class="hint">Context will be retrieved from your vault to answer your questions.</p>
+        {:else}
+          <p>Ask a question.</p>
+          <p class="hint">Use [[note]] to include specific notes as context.</p>
+        {/if}
+      </div>
+    {:else}
+      {#each $store.history as turn, index (`turn-${index}`)}
+        <div class="message user-message">
+          {#if editingIndex === index}
+            <div class="edit-container">
+              <textarea
+                class="edit-input"
+                bind:value={editingText}
+                onkeydown={(e) => handleEditKeydown(e, index)}
+              ></textarea>
+              <div class="edit-actions">
+                <button class="edit-submit" onclick={() => submitEdit(index)}>Send</button>
+                <button class="edit-cancel" onclick={cancelEditing}>Cancel</button>
+              </div>
+            </div>
+          {:else}
+            <div class="message-row">
+              <div class="message-actions" class:disabled={$store.status === 'processing'}>
+                <button
+                  class="action-btn"
+                  title="Delete"
+                  onclick={() => handleDelete(index)}
+                  disabled={$store.status === 'processing'}
+                >
+                  <span use:setupIcon={Trash2}></span>
+                </button>
+                <button
+                  class="action-btn"
+                  title="Edit"
+                  onclick={() => startEditing(index, turn.userMessage)}
+                  disabled={$store.status === 'processing'}
+                >
+                  <span use:setupIcon={Pencil}></span>
+                </button>
+                <button
+                  class="action-btn"
+                  title="Copy"
+                  onclick={() => handleCopy(turn.userMessage)}
+                  disabled={$store.status === 'processing'}
+                >
+                  <span use:setupIcon={Copy}></span>
+                </button>
+              </div>
+              <div class="message-content" use:setMessageElement={turn.userMessage}></div>
+            </div>
+          {/if}
+        </div>
+        <div class="message assistant-message">
+          <div class="message-row">
+            <div class="message-content" use:setMessageElement={turn.assistantMessage}></div>
+            <div class="message-actions" class:disabled={$store.status === 'processing'}>
+              <button
+                class="action-btn"
+                title="Copy"
+                onclick={() => handleCopy(turn.assistantMessage)}
+                disabled={$store.status === 'processing'}
+              >
+                <span use:setupIcon={Copy}></span>
+              </button>
+            </div>
+          </div>
+        </div>
+      {/each}
+    {/if}
+
+    {#if $store.pendingUserMessage}
+      <div class="message user-message">
+        <div class="message-row">
+          <div class="message-actions disabled">
+            <button class="action-btn" disabled aria-label="Delete">
+              <span use:setupIcon={Trash2}></span>
+            </button>
+            <button class="action-btn" disabled aria-label="Edit">
+              <span use:setupIcon={Pencil}></span>
+            </button>
+            <button class="action-btn" disabled aria-label="Copy">
+              <span use:setupIcon={Copy}></span>
+            </button>
+          </div>
+          <div class="message-content" use:setMessageElement={$store.pendingUserMessage}></div>
+        </div>
+      </div>
+    {/if}
+
+    {#if $store.status === 'processing'}
+      <div class="message assistant-message processing">
+        <div class="message-row">
+          <div class="message-content">
+            {#if $store.streamingContent}
+              <span class="streaming-text" use:setMessageElement={$store.streamingContent}></span>
+              <span class="cursor-blink">|</span>
+            {:else if $store.processingPhase === 'retrieving'}
+              <span class="thinking-indicator">Retrieving context...</span>
+            {:else}
+              <span class="thinking-indicator">Generating...</span>
+            {/if}
+          </div>
+          <div class="message-actions disabled">
+            <button class="action-btn" disabled aria-label="Copy">
+              <span use:setupIcon={Copy}></span>
+            </button>
+          </div>
+        </div>
+      </div>
+    {/if}
+
+    {#if $store.errorMessage}
+      <div class="error-message">
+        Error: {$store.errorMessage}
+      </div>
+    {/if}
+  </div>
+
+  {#if $store.status !== 'ready' && $store.status !== 'error'}
+    <div class="status-bar">
+      {getStatusText($store.status)}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .rag-view {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    padding: 16px;
+    overflow: hidden;
+  }
+
+  .rag-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--background-modifier-border);
+    position: relative;
+    z-index: 10;
+    flex-shrink: 0;
+  }
+
+  .header-title {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+
+  .rag-header h3 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+  }
+
+  .model-name {
+    font-size: 12px;
+    color: var(--text-muted);
+    font-weight: 400;
+  }
+
+  .header-controls {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .context-toggle {
+    padding: 4px 10px;
+    font-size: 11px;
+    font-weight: 600;
+    background: var(--background-modifier-border);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--text-muted);
+    transition: all 0.15s ease;
+  }
+
+  .context-toggle:hover {
+    background: var(--background-modifier-hover);
+    color: var(--text-normal);
+  }
+
+  .context-toggle.active {
+    background: var(--interactive-accent);
+    color: var(--text-on-accent);
+  }
+
+  .context-toggle.active:hover {
+    background: var(--interactive-accent-hover);
+  }
+
+  .clear-button {
+    padding: 4px 12px;
+    font-size: 12px;
+    background: var(--background-modifier-border);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--text-muted);
+  }
+
+  .clear-button:hover {
+    background: var(--background-modifier-hover);
+    color: var(--text-normal);
+  }
+
+  .messages-container {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    margin-bottom: 16px;
+    padding-right: 8px;
+  }
+
+  .empty-state {
+    text-align: center;
+    padding: 32px;
+    color: var(--text-muted);
+  }
+
+  .empty-state p {
+    margin: 8px 0;
+  }
+
+  .empty-state .hint {
+    font-size: 12px;
+    opacity: 0.8;
+  }
+
+  .message {
+    margin-bottom: 16px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .user-message {
+    align-items: flex-end;
+  }
+
+  .user-message .message-content {
+    background: var(--background-primary-alt);
+    padding: 10px 14px;
+    border-radius: 16px 16px 4px 16px;
+    border: 1px solid var(--interactive-accent);
+    user-select: text;
+    cursor: text;
+  }
+
+  .assistant-message {
+    align-items: flex-start;
+  }
+
+  .assistant-message .message-content {
+    background: var(--background-secondary);
+    padding: 10px 14px;
+    border-radius: 16px 16px 16px 4px;
+    border: 1px solid var(--background-modifier-border);
+  }
+
+  .message-content {
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--text-normal);
+    user-select: text;
+    cursor: text;
+  }
+
+  .message-content :global(p) {
+    margin: 0 0 8px 0;
+  }
+
+  .message-content :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  .processing .message-content {
+    background: var(--background-secondary);
+    padding: 10px 14px;
+    border-radius: 16px 16px 16px 4px;
+    border: 1px solid var(--background-modifier-border);
+  }
+
+  .thinking-indicator {
+    display: inline-block;
+    color: var(--text-muted);
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 1; }
+  }
+
+  .streaming-text {
+    display: inline;
+  }
+
+  .cursor-blink {
+    animation: blink 1s step-end infinite;
+    font-weight: bold;
+  }
+
+  @keyframes blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+  }
+
+  .error-message {
+    padding: 12px;
+    margin-bottom: 16px;
+    background: rgba(255, 0, 0, 0.1);
+    border: 1px solid rgba(255, 0, 0, 0.3);
+    border-radius: 8px;
+    color: var(--text-error);
+    font-size: 13px;
+  }
+
+  .status-bar {
+    margin-top: 8px;
+    padding: 8px;
+    text-align: center;
+    font-size: 12px;
+    color: var(--text-muted);
+    background: var(--background-secondary);
+    border-radius: 4px;
+  }
+
+  .messages-container::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .messages-container::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .messages-container::-webkit-scrollbar-thumb {
+    background: var(--background-modifier-border);
+    border-radius: 4px;
+  }
+
+  .messages-container::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
+  }
+
+  .message-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .user-message .message-row {
+    flex-direction: row;
+  }
+
+  .assistant-message .message-row {
+    flex-direction: row;
+  }
+
+  .message-actions {
+    display: flex;
+    gap: 2px;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    flex-shrink: 0;
+    align-items: center;
+  }
+
+  .message:hover .message-actions:not(.disabled) {
+    opacity: 1;
+  }
+
+  .message-actions.disabled {
+    pointer-events: none;
+  }
+
+  .action-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.15s ease;
+  }
+
+  .action-btn:hover {
+    background: var(--background-modifier-hover);
+    color: var(--text-normal);
+  }
+
+  .edit-container {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 90%;
+  }
+
+  .edit-input {
+    width: 100%;
+    min-height: 60px;
+    padding: 10px 14px;
+    border: 1px solid var(--interactive-accent);
+    border-radius: 8px;
+    background: var(--background-primary);
+    color: var(--text-normal);
+    font-size: 14px;
+    line-height: 1.5;
+    resize: vertical;
+  }
+
+  .edit-input:focus {
+    outline: none;
+    border-color: var(--interactive-accent);
+    box-shadow: 0 0 0 2px rgba(var(--interactive-accent-rgb), 0.2);
+  }
+
+  .edit-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+  }
+
+  .edit-submit {
+    padding: 6px 16px;
+    background: var(--interactive-accent);
+    color: var(--text-on-accent);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  .edit-submit:hover {
+    background: var(--interactive-accent-hover);
+  }
+
+  .edit-cancel {
+    padding: 6px 16px;
+    background: var(--background-modifier-border);
+    color: var(--text-muted);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+  }
+
+  .edit-cancel:hover {
+    background: var(--background-modifier-hover);
+    color: var(--text-normal);
+  }
+</style>

--- a/src/ui/FileSuggestModal.ts
+++ b/src/ui/FileSuggestModal.ts
@@ -1,0 +1,74 @@
+import { App, FuzzySuggestModal, TFile } from 'obsidian';
+
+interface RecentFilesPluginData {
+  recentFiles?: { basename: string; path: string }[];
+}
+
+function getRecentFilePaths(app: App): Set<string> {
+  // Try Recent Files plugin first (provides more entries)
+  const recentFilesPlugin = (
+    app as App & {
+      plugins?: {
+        plugins?: {
+          'recent-files-obsidian'?: { data?: RecentFilesPluginData };
+        };
+      };
+    }
+  ).plugins?.plugins?.['recent-files-obsidian'];
+  const pluginRecentFiles = recentFilesPlugin?.data?.recentFiles;
+  if (pluginRecentFiles && pluginRecentFiles.length > 0) {
+    return new Set(pluginRecentFiles.map(f => f.path));
+  }
+
+  // Fallback to standard API (limited to 10 files)
+  return new Set(app.workspace.getLastOpenFiles());
+}
+
+/**
+ * Modal for fuzzy file selection
+ * Returns the selected file's name suitable for wikilink insertion
+ */
+export class FileSuggestModal extends FuzzySuggestModal<TFile> {
+  private files: TFile[];
+  private onSelect: (file: TFile) => void;
+
+  constructor(app: App, files: TFile[], onSelect: (file: TFile) => void) {
+    super(app);
+    this.files = files;
+    this.onSelect = onSelect;
+    this.setPlaceholder('Select a file to reference...');
+  }
+
+  getItems(): TFile[] {
+    const recentPaths = getRecentFilePaths(this.app);
+    const recent: TFile[] = [];
+    const others: TFile[] = [];
+    for (const file of this.files) {
+      if (recentPaths.has(file.path)) {
+        recent.push(file);
+      } else {
+        others.push(file);
+      }
+    }
+    return [...recent, ...others];
+  }
+
+  getItemText(file: TFile): string {
+    return file.basename;
+  }
+
+  onChooseItem(file: TFile): void {
+    this.onSelect(file);
+  }
+}
+
+/**
+ * Get the wikilink text for a file
+ * Markdown files use basename, other files include extension
+ */
+export function getWikilinkForFile(file: TFile): string {
+  if (file.extension === 'md') {
+    return file.basename;
+  }
+  return file.name;
+}

--- a/styles.css
+++ b/styles.css
@@ -28,7 +28,148 @@ body.sonar-modal-open .hover-popover {
   padding: 0px !important;
 }
 
-/* Settings tab */
+/* RAG View */
+.rag-view-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 0 !important;
+  position: relative;
+}
+
+.rag-messages-wrapper {
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.rag-input-container {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  padding: 12px 16px;
+  border-top: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+  flex-shrink: 0;
+  position: relative;
+  z-index: 10;
+}
+
+.rag-message-input {
+  flex: 1;
+  min-width: 0;
+  min-height: 36px;
+  max-height: 200px;
+  padding: 8px 12px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  background: var(--background-primary);
+  color: var(--text-normal);
+  font-size: 14px;
+  line-height: 1.4;
+  resize: none;
+  overflow-y: auto;
+}
+
+.rag-send-button {
+  padding: 8px 16px;
+  min-height: 36px;
+  min-width: 60px;
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.rag-send-button:hover {
+  background: var(--interactive-accent-hover);
+}
+
+.rag-send-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.8;
+}
+
+.rag-send-button.is-loading {
+  position: relative;
+}
+
+.rag-send-button.is-loading::after {
+  content: '';
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--text-on-accent);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.rag-send-button.is-loading:hover {
+  background: var(--background-modifier-error);
+}
+
+.rag-send-button.is-loading:hover::after {
+  content: 'Stop';
+  width: auto;
+  height: auto;
+  border: none;
+  animation: none;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Settings tab - shared collapsible styles */
+.sonar-settings-section summary,
+.sonar-settings-subsection summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 8px 0;
+  user-select: none;
+}
+
+.sonar-settings-section summary::-webkit-details-marker,
+.sonar-settings-subsection summary::-webkit-details-marker {
+  display: none;
+}
+
+.sonar-settings-section summary::before,
+.sonar-settings-subsection summary::before {
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: transparent transparent transparent var(--text-muted);
+  transition: transform 0.2s ease;
+  vertical-align: middle;
+}
+
+.sonar-settings-section[open] summary::before,
+.sonar-settings-subsection[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.sonar-settings-section summary:hover,
+.sonar-settings-subsection summary:hover {
+  color: var(--text-accent);
+}
+
+.sonar-settings-section summary:hover::before,
+.sonar-settings-subsection summary:hover::before {
+  border-left-color: var(--text-accent);
+}
+
+/* Settings section specific styles */
 .sonar-settings-section {
   padding-bottom: 20px;
   margin-bottom: 20px;
@@ -45,39 +186,30 @@ body.sonar-modal-open .hover-popover {
   font-weight: 600;
   color: var(--text-normal);
   margin-bottom: 16px;
-  cursor: pointer;
-  list-style: none;
-  padding: 8px 0;
-  user-select: none;
-}
-
-.sonar-settings-section summary::-webkit-details-marker {
-  display: none;
 }
 
 .sonar-settings-section summary::before {
-  content: '';
-  display: inline-block;
-  width: 0;
-  height: 0;
-  border-style: solid;
   border-width: 6px 0 6px 10px;
-  border-color: transparent transparent transparent var(--text-muted);
   margin-right: 10px;
-  transition: transform 0.2s ease;
-  vertical-align: middle;
 }
 
-.sonar-settings-section[open] summary::before {
-  transform: rotate(90deg);
+/* Settings subsection specific styles */
+.sonar-settings-subsection {
+  margin-top: 16px;
+  padding: 12px;
+  background: var(--background-secondary);
+  border-radius: 6px;
 }
 
-.sonar-settings-section summary:hover {
-  color: var(--text-accent);
+.sonar-settings-subsection summary {
+  font-size: 1em;
+  font-weight: 500;
+  color: var(--text-muted);
 }
 
-.sonar-settings-section summary:hover::before {
-  border-left-color: var(--text-accent);
+.sonar-settings-subsection summary::before {
+  border-width: 4px 0 4px 6px;
+  margin-right: 8px;
 }
 
 .sonar-stats-in-settings {


### PR DESCRIPTION
Add a chat interface that uses local LLM with optional context retrieval from the vault.

Core components:
- `Chat`: Manages conversation history and message building with token budget management. Automatically trims old context/messages to fit within context window.
- `ChatContextBuilder`: Builds context from semantic search and explicit [[wikilink]] references. Moved from `RAGContextBuilder` with clearer responsibility separation.
- `ChatView` + `ChatViewContent.svelte`: Chat UI with streaming responses, message editing/deletion, and wikilink insertion.

LLM integration:
- Streaming chat completion via SSE (`llamaServerChatCompletionStream`)
- Configurable generation parameters (temperature, top-p, top-k, presence penalty) in settings
- Support for Qwen3 thinking mode via `--jinja` template
- Lazy model initialization when chat view is opened

UI features:
- Real-time streaming with cursor indicator
- Cancel generation (restores message to input for editing)
- Edit/delete conversation turns
- Insert [[wikilinks]] via file picker (Ctrl+L / Cmd+L)
- Auto-scroll during streaming, preserved when user scrolls up
- Collapsible "Generation parameters" subsection in settings

Settings additions:
- Chat configuration: max tokens, thinking mode toggle
- RAG configuration: enable context, context token budget
- Generation parameters: temperature, top-p, top-k, presence penalty