### PR TITLE
benchmark: Exclude benchmark code from production builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,12 @@ instructions.
 ## Build
 
 ```bash
-npm run build         # Quick build with type checking (`skipLibCheck` enabled)
+npm run build                 # Production build (without benchmark code)
+npm run build:with-benchmark  # Development build (includes benchmark code)
 ```
+
+Benchmark code is excluded from production builds to keep the plugin small. Use
+`build:with-benchmark` when you need to run retrieval or RAG benchmarks.
 
 ## Code quality checks
 
@@ -201,6 +205,37 @@ format conventions:
 - Avoid long-running tasks during `onload`; use lazy initialization.
 - Batch disk access and avoid excessive vault scans.
 - Debounce/throttle expensive operations in response to file system events.
+
+### Benchmark code structure
+
+Benchmark code is separated from the main plugin to keep production builds
+small. The code is conditionally compiled using the `INCLUDE_BENCHMARK`
+environment variable.
+
+```
+retrieval-bench/
+  src/
+    BenchmarkRunner.ts   # Retrieval-only benchmarks (BM25, Vector, Hybrid)
+    settings.ts          # Settings UI for retrieval benchmarks
+    index.ts             # Command registration
+  scripts/               # Python scripts for data processing
+
+rag-bench/
+  src/
+    CragBenchmarkRunner.ts  # End-to-end RAG benchmarks (CRAG)
+    settings.ts             # Settings UI for CRAG benchmarks
+    index.ts                # Command registration
+```
+
+Build commands:
+
+- `npm run build` - Production build without benchmark code
+- `npm run build:with-benchmark` - Includes benchmark code
+- `npm run dev:with-benchmark` - Watch mode with benchmark code
+
+Benchmark settings in `src/config.ts` are optional fields that only appear in
+development builds. The settings UI sections are conditionally loaded via
+dynamic imports when `process.env.INCLUDE_BENCHMARK === 'true'`.
 
 ### Versioning & releases
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,9 +15,9 @@ export default [
       'node_modules/**',
       'main.js',
       'src/generated/**',
-      'retrieval-bench',
-      'rag-bench',
-      'experiments',
+      'retrieval-bench/**',
+      'rag-bench/**',
+      'experiments/**',
       '.venv/**',
       'extension-tools/**/*.js', // Extension tool example scripts (dynamically loaded)
     ],

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "type": "module",
   "scripts": {
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+    "build:with-benchmark": "tsc -noEmit -skipLibCheck && INCLUDE_BENCHMARK=true node esbuild.config.mjs production",
     "clean": "rm main.js",
     "dev": "node esbuild.config.mjs",
+    "dev:with-benchmark": "INCLUDE_BENCHMARK=true node esbuild.config.mjs",
     "deploy": "./deploy.sh",
     "version": "node version-bump.mjs && git add manifest.json versions.json",
     "sonar": "npx tsx scripts/sonar.ts",

--- a/rag-bench/README.md
+++ b/rag-bench/README.md
@@ -7,8 +7,9 @@ generates correct answers.
 ## Purpose
 
 Demonstrate Sonar's RAG accuracy numerically by comparing against published
-baselines. Unlike the retrieval-only benchmarks in `retrieval-bench/`, this
-evaluates the complete pipeline: retrieval → reranking → LLM answer generation.
+baselines. Unlike the retrieval-only benchmarks in
+[`retrieval-bench`](../retrieval-bench/README.md), this evaluates the complete
+pipeline: retrieval → reranking → LLM answer generation.
 
 Key questions:
 

--- a/rag-bench/src/CragBenchmarkRunner.ts
+++ b/rag-bench/src/CragBenchmarkRunner.ts
@@ -2,11 +2,11 @@ import { Notice, requestUrl, type RequestUrlResponse } from 'obsidian';
 import { createReadStream, promises as fs } from 'fs';
 import { join, isAbsolute } from 'path';
 import { createInterface } from 'readline';
-import { WithLogging } from './WithLogging';
-import type { ConfigManager } from './ConfigManager';
-import type { LlamaCppEmbedder } from './LlamaCppEmbedder';
-import type { LlamaCppReranker } from './LlamaCppReranker';
-import type { LlamaCppChat, ChatMessageExtended } from './LlamaCppChat';
+import { WithLogging } from '../../src/WithLogging';
+import type { ConfigManager } from '../../src/ConfigManager';
+import type { LlamaCppEmbedder } from '../../src/LlamaCppEmbedder';
+import type { LlamaCppReranker } from '../../src/LlamaCppReranker';
+import type { LlamaCppChat, ChatMessageExtended } from '../../src/LlamaCppChat';
 import {
   MetadataStore,
   type ChunkMetadata,
@@ -18,14 +18,14 @@ import {
   STORE_BM25_DOC_TOKENS,
   STORE_FAILED_FILES,
   INDEX_FILE_PATH,
-} from './MetadataStore';
-import { EmbeddingStore } from './EmbeddingStore';
-import { BM25Store } from './BM25Store';
-import { EmbeddingSearch } from './EmbeddingSearch';
-import { BM25Search } from './BM25Search';
-import { SearchManager, type ChunkResult } from './SearchManager';
-import { createChunks } from './chunker';
-import { ChunkId } from './chunkId';
+} from '../../src/MetadataStore';
+import { EmbeddingStore } from '../../src/EmbeddingStore';
+import { BM25Store } from '../../src/BM25Store';
+import { EmbeddingSearch } from '../../src/EmbeddingSearch';
+import { BM25Search } from '../../src/BM25Search';
+import { SearchManager, type ChunkResult } from '../../src/SearchManager';
+import { createChunks } from '../../src/chunker';
+import { ChunkId } from '../../src/chunkId';
 
 const OPENAI_API_URL = 'https://api.openai.com/v1/chat/completions';
 const EVALUATION_MODEL = 'gpt-4o-mini';

--- a/rag-bench/src/index.ts
+++ b/rag-bench/src/index.ts
@@ -1,0 +1,77 @@
+import { Notice } from 'obsidian';
+import type SonarPlugin from '../../main';
+import { DEFAULT_SETTINGS } from '../../src/config';
+import { LlamaCppChat } from '../../src/LlamaCppChat';
+import { CragBenchmarkRunner } from './CragBenchmarkRunner';
+
+export { CragBenchmarkRunner } from './CragBenchmarkRunner';
+export { createCragBenchmarkSettings } from './settings';
+
+export function registerCragBenchmarkCommands(plugin: SonarPlugin): void {
+  plugin.addCommand({
+    id: 'run-crag-benchmark',
+    name: 'Run CRAG benchmark (end-to-end RAG)',
+    callback: async () => {
+      if (!plugin.embedder || !plugin.reranker) {
+        new Notice('Sonar is not initialized yet');
+        return;
+      }
+
+      const dataPath = plugin.configManager.get('cragDataPath');
+      const outputDir = plugin.configManager.get('cragOutputDir');
+
+      if (!dataPath || !outputDir) {
+        new Notice(
+          'CRAG benchmark paths not configured.\n' +
+            'Set cragDataPath and cragOutputDir in settings.'
+        );
+        return;
+      }
+
+      // Initialize chat model for answer generation
+      const serverPath = plugin.configManager.get('llamacppServerPath');
+      const chatModelRepo =
+        plugin.configManager.get('llamaChatModelRepo') ||
+        DEFAULT_SETTINGS.llamaChatModelRepo;
+      const chatModelFile =
+        plugin.configManager.get('llamaChatModelFile') ||
+        DEFAULT_SETTINGS.llamaChatModelFile;
+
+      const chatModel = new LlamaCppChat(
+        serverPath,
+        chatModelRepo,
+        chatModelFile,
+        plugin.configManager,
+        (msg, duration) => new Notice(msg, duration),
+        (modelId: string) => plugin.confirmModelDownload('chat', modelId)
+      );
+
+      try {
+        new Notice('Initializing chat model for CRAG benchmark...');
+        await chatModel.initialize();
+
+        const vaultBasePath = (plugin.app.vault.adapter as any).basePath || '';
+        const benchmarkRunner = new CragBenchmarkRunner(
+          plugin.configManager,
+          plugin.embedder,
+          plugin.reranker,
+          chatModel,
+          vaultBasePath
+        );
+
+        await benchmarkRunner.runBenchmark({
+          dataPath,
+          outputDir,
+          sampleSize: plugin.configManager.get('cragSampleSize'),
+        });
+      } catch (error) {
+        plugin.configManager
+          .getLogger()
+          .error(`[Sonar.Plugin] CRAG benchmark failed: ${error}`);
+        new Notice(`CRAG benchmark failed: ${error}`);
+      } finally {
+        await chatModel.cleanup();
+      }
+    },
+  });
+}

--- a/rag-bench/src/settings.ts
+++ b/rag-bench/src/settings.ts
@@ -1,0 +1,99 @@
+import { App, MarkdownRenderer, Setting } from 'obsidian';
+import type { ConfigManager } from '../../src/ConfigManager';
+import type SonarPlugin from '../../main';
+
+function renderMarkdownDesc(
+  app: App,
+  plugin: SonarPlugin,
+  el: HTMLElement,
+  markdown: string
+): void {
+  el.empty();
+  el.addClass('sonar-markdown-desc');
+  MarkdownRenderer.render(app, markdown, el, '', plugin);
+}
+
+export function createCragBenchmarkSettings(
+  app: App,
+  plugin: SonarPlugin,
+  containerEl: HTMLElement,
+  configManager: ConfigManager
+): void {
+  const cragDetails = containerEl.createEl('details', {
+    cls: 'sonar-settings-section',
+  });
+  cragDetails.createEl('summary', { text: 'CRAG benchmark (end-to-end RAG)' });
+  const cragContainer = cragDetails.createDiv();
+
+  const dataPathSetting = new Setting(cragContainer).setName('CRAG data path');
+  renderMarkdownDesc(
+    app,
+    plugin,
+    dataPathSetting.descEl,
+    'Path to `data.jsonl` file for CRAG benchmark. Can be absolute or relative to vault root.'
+  );
+  dataPathSetting.addText(text =>
+    text
+      .setPlaceholder('rag-bench/data.jsonl or /absolute/path/to/data.jsonl')
+      .setValue(configManager.get('cragDataPath'))
+      .onChange(async value => await configManager.set('cragDataPath', value))
+  );
+
+  const outputDirSetting = new Setting(cragContainer).setName(
+    'CRAG output directory'
+  );
+  renderMarkdownDesc(
+    app,
+    plugin,
+    outputDirSetting.descEl,
+    'Path to directory for CRAG benchmark output. Can be absolute or relative to vault root.'
+  );
+  outputDirSetting.addText(text =>
+    text
+      .setPlaceholder('rag-bench/output or /absolute/path/to/output')
+      .setValue(configManager.get('cragOutputDir'))
+      .onChange(async value => await configManager.set('cragOutputDir', value))
+  );
+
+  const sampleSizeSetting = new Setting(cragContainer).setName(
+    'CRAG sample size'
+  );
+  renderMarkdownDesc(
+    app,
+    plugin,
+    sampleSizeSetting.descEl,
+    'Number of samples to process (`0` = all samples).'
+  );
+  sampleSizeSetting.addText(text =>
+    text
+      .setPlaceholder('0')
+      .setValue(String(configManager.get('cragSampleSize')))
+      .onChange(async value => {
+        const num = parseInt(value, 10);
+        if (!isNaN(num) && num >= 0) {
+          await configManager.set('cragSampleSize', num);
+        }
+      })
+  );
+
+  const apiKeySetting = new Setting(cragContainer).setName('OpenAI API key');
+  renderMarkdownDesc(
+    app,
+    plugin,
+    apiKeySetting.descEl,
+    'API key for OpenAI (used for LLM-as-judge evaluation).'
+  );
+  apiKeySetting.addText(text =>
+    text
+      .setPlaceholder('sk-...')
+      .setValue(configManager.get('cragOpenaiApiKey'))
+      .onChange(
+        async value => await configManager.set('cragOpenaiApiKey', value)
+      )
+  );
+  // Make API key input a password field
+  const inputEl = apiKeySetting.controlEl.querySelector('input');
+  if (inputEl) {
+    inputEl.type = 'password';
+  }
+}

--- a/retrieval-bench/src/RetrievalBenchmarkRunner.ts
+++ b/retrieval-bench/src/RetrievalBenchmarkRunner.ts
@@ -1,9 +1,9 @@
 import { Notice } from 'obsidian';
 import type { App } from 'obsidian';
-import { WithLogging } from './WithLogging';
-import type { ConfigManager } from './ConfigManager';
-import type { SearchManager, SearchOptions } from './SearchManager';
-import type { IndexManager } from './IndexManager';
+import { WithLogging } from '../../src/WithLogging';
+import type { ConfigManager } from '../../src/ConfigManager';
+import type { SearchManager, SearchOptions } from '../../src/SearchManager';
+import type { IndexManager } from '../../src/IndexManager';
 import { join, dirname, isAbsolute } from 'path';
 import { promises as fs } from 'fs';
 
@@ -42,7 +42,7 @@ interface RunEvaluation {
  * Benchmark runner for evaluating Sonar against other retrieval systems.
  * Reads queries from JSONL file, runs searches, outputs TREC format results.
  */
-export class BenchmarkRunner extends WithLogging {
+export class RetrievalBenchmarkRunner extends WithLogging {
   protected readonly componentName = 'BenchmarkRunner';
 
   constructor(
@@ -290,7 +290,7 @@ export class BenchmarkRunner extends WithLogging {
   ): Promise<TrecResult[]> {
     // Use smaller topK for chunk reranking to limit reranker input size
     // TODO: Add dedicated config for chunk reranking limit
-    const topK = this.configManager.get('benchmarkTopK') / 10;
+    const topK = (this.configManager.get('benchmarkTopK')) / 10;
     const results: TrecResult[] = [];
 
     for (const query of queries) {

--- a/retrieval-bench/src/index.ts
+++ b/retrieval-bench/src/index.ts
@@ -1,0 +1,56 @@
+import { Notice } from 'obsidian';
+import type SonarPlugin from '../../main';
+import { RetrievalBenchmarkRunner } from './RetrievalBenchmarkRunner';
+
+export { RetrievalBenchmarkRunner as BenchmarkRunner } from './RetrievalBenchmarkRunner';
+export { createRetrievalBenchmarkSettings } from './settings';
+
+export function registerRetrievalBenchmarkCommands(plugin: SonarPlugin): void {
+  plugin.addCommand({
+    id: 'run-retrieval-benchmark',
+    name: 'Run retrieval benchmark (BM25, Vector, Hybrid)',
+    callback: async () => {
+      if (!plugin.searchManager || !plugin.indexManager) {
+        new Notice('Sonar is not initialized yet');
+        return;
+      }
+      const retrievalBenchmarkRunner = new RetrievalBenchmarkRunner(
+        plugin.app,
+        plugin.configManager,
+        plugin.searchManager,
+        plugin.indexManager
+      );
+      try {
+        await retrievalBenchmarkRunner.runBenchmark(false);
+      } catch (error) {
+        plugin.configManager
+          .getLogger()
+          .error(`[Sonar.Plugin] Benchmark failed: ${error}`);
+      }
+    },
+  });
+
+  plugin.addCommand({
+    id: 'run-retrieval-benchmark-with-reranking',
+    name: 'Run retrieval benchmark with reranking (BM25, Vector, Hybrid, Hybrid+Rerank)',
+    callback: async () => {
+      if (!plugin.searchManager || !plugin.indexManager) {
+        new Notice('Sonar is not initialized yet');
+        return;
+      }
+      const retrievalBenchmarkRunner = new RetrievalBenchmarkRunner(
+        plugin.app,
+        plugin.configManager,
+        plugin.searchManager,
+        plugin.indexManager
+      );
+      try {
+        await retrievalBenchmarkRunner.runBenchmark(true);
+      } catch (error) {
+        plugin.configManager
+          .getLogger()
+          .error(`[Sonar.Plugin] Benchmark failed: ${error}`);
+      }
+    },
+  });
+}

--- a/retrieval-bench/src/settings.ts
+++ b/retrieval-bench/src/settings.ts
@@ -1,0 +1,100 @@
+import { App, MarkdownRenderer, Setting } from 'obsidian';
+import type { ConfigManager } from '../../src/ConfigManager';
+import type SonarPlugin from '../../main';
+
+function renderMarkdownDesc(
+  app: App,
+  plugin: SonarPlugin,
+  el: HTMLElement,
+  markdown: string
+): void {
+  el.empty();
+  el.addClass('sonar-markdown-desc');
+  MarkdownRenderer.render(app, markdown, el, '', plugin);
+}
+
+export function createRetrievalBenchmarkSettings(
+  app: App,
+  plugin: SonarPlugin,
+  containerEl: HTMLElement,
+  configManager: ConfigManager
+): void {
+  const benchmarkDetails = containerEl.createEl('details', {
+    cls: 'sonar-settings-section',
+  });
+  benchmarkDetails.createEl('summary', { text: 'Retrieval benchmark' });
+  const benchmarkContainer = benchmarkDetails.createDiv();
+
+  const queriesPathSetting = new Setting(benchmarkContainer).setName(
+    'Benchmark queries path'
+  );
+  renderMarkdownDesc(
+    app,
+    plugin,
+    queriesPathSetting.descEl,
+    'Path to `queries.jsonl` file for benchmarks. Can be absolute or relative to vault root.'
+  );
+  queriesPathSetting.addText(text =>
+    text
+      .setPlaceholder(
+        'retrieval-bench/queries.jsonl or /absolute/path/to/queries.jsonl'
+      )
+      .setValue(configManager.get('benchmarkQueriesPath'))
+      .onChange(
+        async value => await configManager.set('benchmarkQueriesPath', value)
+      )
+  );
+
+  const qrelsPathSetting = new Setting(benchmarkContainer).setName(
+    'Benchmark qrels path'
+  );
+  renderMarkdownDesc(
+    app,
+    plugin,
+    qrelsPathSetting.descEl,
+    'Path to `qrels.tsv` file for benchmarks. Can be absolute or relative to vault root.'
+  );
+  qrelsPathSetting.addText(text =>
+    text
+      .setPlaceholder('retrieval-bench/qrels.tsv or /absolute/path/to/qrels.tsv')
+      .setValue(configManager.get('benchmarkQrelsPath'))
+      .onChange(
+        async value => await configManager.set('benchmarkQrelsPath', value)
+      )
+  );
+
+  const outputDirSetting = new Setting(benchmarkContainer).setName(
+    'Benchmark output directory'
+  );
+  renderMarkdownDesc(
+    app,
+    plugin,
+    outputDirSetting.descEl,
+    'Path to directory for TREC output files. Can be absolute or relative to vault root.'
+  );
+  outputDirSetting.addText(text =>
+    text
+      .setPlaceholder('retrieval-bench/output or /absolute/path/to/output')
+      .setValue(configManager.get('benchmarkOutputDir'))
+      .onChange(
+        async value => await configManager.set('benchmarkOutputDir', value)
+      )
+  );
+
+  const topKSetting = new Setting(benchmarkContainer).setName('Benchmark top K');
+  renderMarkdownDesc(
+    app,
+    plugin,
+    topKSetting.descEl,
+    'Number of documents to return for benchmarks (default: `100`).'
+  );
+  topKSetting.addSlider(slider =>
+    slider
+      .setLimits(10, 1000, 10)
+      .setValue(configManager.get('benchmarkTopK'))
+      .setDynamicTooltip()
+      .onChange(
+        async value => await configManager.set('benchmarkTopK', value)
+      )
+  );
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,15 +99,15 @@ export interface SonarSettings {
   statusBarMaxLength: number; // Maximum characters in status bar (0 = no limit)
   debugMode: LogLevel; // Logging verbosity level
 
-  // Benchmark configuration
-  // =======================
+  // Benchmark configuration (optional, only used in development builds)
+  // ===================================================================
   benchmarkQueriesPath: string; // Path to queries.jsonl file (absolute or vault-relative)
   benchmarkQrelsPath: string; // Path to qrels.tsv file (absolute or vault-relative)
   benchmarkOutputDir: string; // Path to directory for TREC output files (absolute or vault-relative)
   benchmarkTopK: number; // Number of documents to return for benchmarks (default: 100)
 
-  // CRAG benchmark configuration
-  // ============================
+  // CRAG benchmark configuration (optional, only used in development builds)
+  // ========================================================================
   cragDataPath: string; // Path to CRAG data.jsonl file (absolute or vault-relative)
   cragOutputDir: string; // Path to directory for CRAG benchmark output (absolute or vault-relative)
   cragSampleSize: number; // Number of samples to process (0 = all)

--- a/src/ui/SettingTab.ts
+++ b/src/ui/SettingTab.ts
@@ -39,7 +39,34 @@ export class SettingTab extends PluginSettingTab {
     this.createChunkingConfigSection(containerEl);
     this.createSearchParamsSection(containerEl);
     this.createLoggingConfigSection(containerEl);
-    this.createBenchmarkConfigSection(containerEl);
+
+    // Benchmark settings are only available in development builds
+    if (process.env.INCLUDE_BENCHMARK === 'true') {
+      this.createBenchmarkConfigSection(containerEl);
+    }
+  }
+
+  private async createBenchmarkConfigSection(
+    containerEl: HTMLElement
+  ): Promise<void> {
+    const { createRetrievalBenchmarkSettings } = await import(
+      '../../retrieval-bench/src/settings'
+    );
+    const { createCragBenchmarkSettings } = await import(
+      '../../rag-bench/src/settings'
+    );
+    createRetrievalBenchmarkSettings(
+      this.app,
+      this.plugin,
+      containerEl,
+      this.configManager
+    );
+    createCragBenchmarkSettings(
+      this.app,
+      this.plugin,
+      containerEl,
+      this.configManager
+    );
   }
 
   hide(): void {
@@ -1158,84 +1185,6 @@ Larger values increase recall but may add noise; smaller values focus on high-qu
         .onChange(
           async value =>
             await this.configManager.set('audioTranscriptionLanguage', value)
-        )
-    );
-  }
-
-  private createBenchmarkConfigSection(containerEl: HTMLElement): void {
-    const benchmarkDetails = containerEl.createEl('details', {
-      cls: 'sonar-settings-section',
-    });
-    benchmarkDetails.createEl('summary', { text: 'Benchmark configuration' });
-    const benchmarkContainer = benchmarkDetails.createDiv();
-
-    const queriesPathSetting = new Setting(benchmarkContainer).setName(
-      'Benchmark queries path'
-    );
-    this.renderMarkdownDesc(
-      queriesPathSetting.descEl,
-      'Path to `queries.jsonl` file for benchmarks. Can be absolute or relative to vault root.'
-    );
-    queriesPathSetting.addText(text =>
-      text
-        .setPlaceholder(
-          'bench/queries.jsonl or /absolute/path/to/queries.jsonl'
-        )
-        .setValue(this.configManager.get('benchmarkQueriesPath'))
-        .onChange(
-          async value =>
-            await this.configManager.set('benchmarkQueriesPath', value)
-        )
-    );
-
-    const qrelsPathSetting = new Setting(benchmarkContainer).setName(
-      'Benchmark qrels path'
-    );
-    this.renderMarkdownDesc(
-      qrelsPathSetting.descEl,
-      'Path to `qrels.tsv` file for benchmarks. Can be absolute or relative to vault root.'
-    );
-    qrelsPathSetting.addText(text =>
-      text
-        .setPlaceholder('bench/qrels.tsv or /absolute/path/to/qrels.tsv')
-        .setValue(this.configManager.get('benchmarkQrelsPath'))
-        .onChange(
-          async value =>
-            await this.configManager.set('benchmarkQrelsPath', value)
-        )
-    );
-
-    const outputDirSetting = new Setting(benchmarkContainer).setName(
-      'Benchmark output directory'
-    );
-    this.renderMarkdownDesc(
-      outputDirSetting.descEl,
-      'Path to directory for TREC output files. Can be absolute or relative to vault root.'
-    );
-    outputDirSetting.addText(text =>
-      text
-        .setPlaceholder('bench/output or /absolute/path/to/output')
-        .setValue(this.configManager.get('benchmarkOutputDir'))
-        .onChange(
-          async value =>
-            await this.configManager.set('benchmarkOutputDir', value)
-        )
-    );
-
-    const topKSetting = new Setting(benchmarkContainer).setName(
-      'Benchmark top K'
-    );
-    this.renderMarkdownDesc(
-      topKSetting.descEl,
-      'Number of documents to return for benchmarks (default: `100`).'
-    );
-    topKSetting.addSlider(slider =>
-      slider
-        .setLimits(10, 1000, 10)
-        .setValue(this.configManager.get('benchmarkTopK'))
-        .setDynamicTooltip()
-        .onChange(
-          async value => await this.configManager.set('benchmarkTopK', value)
         )
     );
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,13 @@
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["src/**/*.ts", "cli/**/*.ts", "main.ts", "**/*.svelte"],
+  "include": [
+    "src/**/*.ts",
+    "cli/**/*.ts",
+    "main.ts",
+    "**/*.svelte",
+    "retrieval-bench/src/**/*.ts",
+    "rag-bench/src/**/*.ts"
+  ],
   "exclude": ["node_modules", "out", "experiments"]
 }


### PR DESCRIPTION
Move benchmark code to dedicated directories (`retrieval-bench/src/`, `rag-bench/src/`) and use build-time conditional compilation to exclude them from production builds. This keeps the plugin small for end users.

Key changes:
- Add `INCLUDE_BENCHMARK` environment variable for conditional compilation
- Mark benchmark paths as external in esbuild when not including benchmarks
- Use dynamic imports in `main.ts` and `SettingTab.ts` for benchmark code
- Make benchmark-related settings optional in `src/config.ts`
- Add `build:with-benchmark` and `dev:with-benchmark` npm scripts
- Update `tsconfig.json` to include benchmark directories for type checking
- Fix ESLint ignore patterns to use proper glob syntax (`/**`)

Production build is now ~28KB smaller (664KB vs 693KB).