### PR TITLE
chat: Add vault context file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Diff:
 [`0.1.5...HEAD`](https://github.com/aviatesk/obsidian-sonar/compare/0.1.5...HEAD)
 
+### Added
+
+- Vault context file support: specify a markdown file in settings to provide
+  context about your vault (structure, conventions, preferences) to the chat
+  assistant via the system prompt.
+
 ## 0.1.5
 
 Diff:

--- a/README.md
+++ b/README.md
@@ -288,6 +288,36 @@ provided, including web search via SearXNG and calendar integrations. See
 [extension-tools/README.md](./extension-tools/README.md) for the API and setup
 instructions.
 
+#### Vault context
+
+You can provide custom context about your vault to help the assistant understand
+your vault structure and preferences. Create a markdown file anywhere in your
+vault and specify its path in **Settings → Sonar → Chat configuration → Vault
+context file**.
+
+Example vault context file:
+
+```markdown
+## About this vault
+
+This vault contains my research notes on machine learning and software
+engineering.
+
+## Folder structure
+
+- `research/`: Academic papers and reading notes
+- `projects/`: Active project documentation
+- `journal/`: Daily notes and reflections
+
+## Preferences
+
+- I prefer concise, technical responses
+- When searching for ML topics, prioritize the `research/` folder
+```
+
+The content is included in the system prompt, so the assistant can use this
+information when searching your vault or answering questions.
+
 ---
 
 ## Development

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,6 +78,10 @@ export interface SonarSettings {
   // ---------------
   extensionToolsPath: string; // Vault folder containing extension tool scripts (.js files)
 
+  // Vault context
+  // -------------
+  vaultContextFilePath: string; // Path to markdown file containing vault context for chat
+
   // Search parameters
   // =================
   bm25AggMethod: AggregationMethod; // BM25 aggregation method (default: 'max_p')
@@ -185,6 +189,8 @@ export const DEFAULT_SETTINGS: SonarSettings = {
   fetchUrlEnabled: false,
   // Extension tools
   extensionToolsPath: '',
+  // Vault context
+  vaultContextFilePath: '',
 
   // Search parameters
   // =================

--- a/src/ui/ChatView.ts
+++ b/src/ui/ChatView.ts
@@ -308,6 +308,7 @@ export class ChatView extends ItemView {
     const extensionCount = await this.loadExtensionTools(toolRegistry);
 
     this.chatManager = new ChatManager(
+      this.app,
       this.chatModel,
       toolRegistry,
       this.configManager

--- a/src/ui/ChatViewContent.svelte
+++ b/src/ui/ChatViewContent.svelte
@@ -248,6 +248,13 @@
   function getExtensionTools(): ToolConfig[] {
     return $store.tools.filter(t => !t.isBuiltin);
   }
+
+  function getVaultContextLabel(): string | null {
+    const path = configManager.get('vaultContextFilePath');
+    if (!path) return null;
+    const basename = path.split('/').pop() ?? path;
+    return basename.replace(/\.md$/, '');
+  }
 </script>
 
 <div class="rag-view">
@@ -263,6 +270,12 @@
           <span class="tools-count">{getEnabledToolCount()}/{$store.tools.length}</span>
           <span class="tools-chevron" class:expanded={toolsExpanded}>▸</span>
         </button>
+      {/if}
+      {#if getVaultContextLabel()}
+        <span class="vault-context-badge" title="Vault context: {configManager.get('vaultContextFilePath')}">
+          <span class="vault-context-icon" use:setupIcon={'file-text'}></span>
+          <span class="vault-context-label">{getVaultContextLabel()}</span>
+        </span>
       {/if}
     </div>
     <div class="header-controls">
@@ -572,6 +585,30 @@
 
   .tools-chevron.expanded {
     transform: rotate(90deg);
+  }
+
+  .vault-context-badge {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: var(--text-muted);
+    font-size: 11px;
+  }
+
+  .vault-context-icon {
+    display: flex;
+    align-items: center;
+  }
+
+  .vault-context-icon :global(svg) {
+    width: 12px;
+    height: 12px;
+  }
+
+  .vault-context-label {
+    font-size: 11px;
   }
 
   .tools-bar {

--- a/src/ui/SettingTab.ts
+++ b/src/ui/SettingTab.ts
@@ -10,7 +10,7 @@ import { ConfigManager } from '../ConfigManager';
 import type SonarPlugin from '../../main';
 import { getIndexableFilesCount } from 'src/fileFilters';
 import type { AggregationMethod, LogLevel } from '../config';
-import { FolderSuggestInput } from '../obsidian-utils';
+import { FileSuggestInput, FolderSuggestInput } from '../obsidian-utils';
 
 export class SettingTab extends PluginSettingTab {
   plugin: SonarPlugin;
@@ -700,6 +700,28 @@ Higher values allow more thorough research but may increase response time.`
             await this.configManager.set('agentMaxIterations', value)
         )
     );
+
+    // Vault context subsection
+    chatContainer.createEl('h4', { text: 'Vault context' });
+
+    const vaultContextSetting = new Setting(chatContainer).setName(
+      'Vault context file'
+    );
+    this.renderMarkdownDesc(
+      vaultContextSetting.descEl,
+      `Path to a markdown file containing context about your vault.
+This content is included in the system prompt to help the assistant understand your vault structure and preferences.`
+    );
+    vaultContextSetting.addSearch(search => {
+      search
+        .setPlaceholder('vault-context.md')
+        .setValue(this.configManager.get('vaultContextFilePath'))
+        .onChange(async value => {
+          const normalized = value ? normalizePath(value) : '';
+          await this.configManager.set('vaultContextFilePath', normalized);
+        });
+      new FileSuggestInput(this.app, search.inputEl);
+    });
 
     // Context settings subsection
     chatContainer.createEl('h4', { text: 'Context settings' });


### PR DESCRIPTION
Add a new setting to specify a markdown file that provides context about the user's vault. The content of this file is included in the system prompt to help the assistant understand vault structure and user preferences.