### PR TITLE
search: Add folder filters and `exclude_folder` tool option

### DIFF
--- a/src/BM25Search.ts
+++ b/src/BM25Search.ts
@@ -1,9 +1,10 @@
 import { BM25Store } from './BM25Store';
 import { MetadataStore } from './MetadataStore';
-import type {
-  ChunkResult,
-  SearchResult,
-  FullSearchOptions,
+import {
+  matchesFolderFilters,
+  type ChunkResult,
+  type SearchResult,
+  type FullSearchOptions,
 } from './SearchManager';
 import type { ConfigManager } from './ConfigManager';
 import { WithLogging } from './WithLogging';
@@ -114,11 +115,11 @@ export class BM25Search extends WithLogging {
 
     const contentChunks = bm25Results.filter(result => {
       if (ChunkId.isTitle(result.docId)) return false;
-      if (options?.excludeFilePath) {
-        const filePath = ChunkId.getFilePath(result.docId);
-        if (filePath === options.excludeFilePath) return false;
+      const filePath = ChunkId.getFilePath(result.docId);
+      if (options?.excludeFilePath && filePath === options.excludeFilePath) {
+        return false;
       }
-      return true;
+      return matchesFolderFilters(filePath, options);
     });
 
     // Apply chunk-level limit

--- a/src/EmbeddingSearch.ts
+++ b/src/EmbeddingSearch.ts
@@ -2,10 +2,11 @@ import { EmbeddingStore } from './EmbeddingStore';
 import { MetadataStore, type ChunkMetadata } from './MetadataStore';
 import type { LlamaCppEmbedder } from './LlamaCppEmbedder';
 import { ConfigManager } from './ConfigManager';
-import type {
-  ChunkResult,
-  SearchResult,
-  FullSearchOptions,
+import {
+  matchesFolderFilters,
+  type ChunkResult,
+  type SearchResult,
+  type FullSearchOptions,
 } from './SearchManager';
 import { WithLogging } from './WithLogging';
 import { hasNaNEmbedding, countNaNValues } from './utils';
@@ -182,10 +183,13 @@ export class EmbeddingSearch extends WithLogging {
 
     let filteredChunks = chunks;
     if (options?.excludeFilePath) {
-      filteredChunks = chunks.filter(
+      filteredChunks = filteredChunks.filter(
         chunk => chunk.metadata.filePath !== options.excludeFilePath
       );
     }
+    filteredChunks = filteredChunks.filter(chunk =>
+      matchesFolderFilters(chunk.metadata.filePath, options)
+    );
 
     const results = filteredChunks.map(chunk => ({
       chunk,


### PR DESCRIPTION
Add `folderPath` and `excludeFolderPath` filters to `searchContent` in `BM25Search` and `EmbeddingSearch`. The shared folder prefix logic is extracted into a
`matchesFolderFilters()` helper in `SearchManager.ts`.

`getRerankedChunksForRAG()` accepts only `excludeFolderPath` (no `folderPath`) since no caller needs folder scoping at the RAG level.

Expose `exclude_folder` as a tool parameter in `search_vault` so the chat model can exclude specific folders from results.